### PR TITLE
Support excluding artifacts. Add a large amount of Maven dependencies required by most Grakn Labs repositories

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -1,13 +1,20 @@
 artifacts = {
     "ch.qos.logback:logback-classic": "1.2.3",
     "ch.qos.logback:logback-core": "1.2.3",
+    "com.fasterxml.jackson.core:jackson-core": "2.9.10",
+    "com.fasterxml.jackson.core:jackson-databind": "2.9.10.1",
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": "2.9.9",
+    "com.fasterxml.jackson.module:jackson-module-scala_2.11": "2.9.9",
     "com.google.code.findbugs:annotations": "3.0.1",
     "com.google.code.findbugs:jsr305": "2.0.2",
     "com.google.guava:guava": "23.0",
     "com.google.protobuf:protobuf-java": "3.5.1",
-    "commons-cli:commons-cli":"1.4",
+    # "commons-cli:commons-cli": "1.3",
+    "commons-cli:commons-cli": "1.4",
+    "commons-collections:commons-collections": "3.2.1",
+    "commons-configuration:commons-configuration": "1.10",
     "commons-io:commons-io": "2.3",
-    "commons-lang:commons-lang":"2.6",
+    "commons-lang:commons-lang": "2.6",
     "io.cucumber:cucumber-java": "5.1.3",
     "io.cucumber:cucumber-junit": "5.1.3",
     "io.grpc:grpc-api": "1.24.1",
@@ -21,21 +28,149 @@ artifacts = {
     "io.netty:netty-handler": "4.1.38.Final",
     "io.netty:netty-handler-proxy": "4.1.38.Final",
     "io.netty:netty-tcnative-boringssl-static": "2.0.25.Final",
-    "javax.annotation:javax.annotation-api":"1.3.2",
-    "jline:jline":"2.12",
+    "io.vavr:vavr": "0.9.0",
+    "javax.annotation:javax.annotation-api": "1.3.2",
+    "javax.servlet:javax.servlet-api": "3.1.0",
+    "jline:jline": "2.12",
     "junit:junit": "4.12",
     "org.antlr:antlr4-runtime": "4.7.1",
+    "org.apache.cassandra:cassandra-all": {
+      "version": "3.11.3",
+      "exclude": [
+        "ch.qos.logback:logback-classic",
+        "ch.qos.logback:logback-core",
+        "it.unimi.dsi:fastutil",
+        "com.addthis.metrics:reporter-config3", # include this if we need to debug cassandra
+        "org.eclipse.jdt.core.compiler:ecj",
+      ]
+    },
+    "org.apache.cassandra:cassandra-thrift": {
+      "version": "3.11.3",
+      "exclude": [
+        "ch.qos.logback:logback-classic",
+        "ch.qos.logback:logback-core",
+        "it.unimi.dsi:fastutil",
+      ]
+    },
     "org.apache.commons:commons-csv": "1.7",
+    # "org.apache.commons:commons-lang3": "3.3.1",
     "org.apache.commons:commons-lang3": "3.9",
+    "org.apache.commons:commons-math3": "3.6.1",
+    "org.apache.hadoop:hadoop-annotations": "2.7.2",
+    "org.apache.thrift:libthrift": "0.9.2",
+    "org.apache.hadoop:hadoop-common": {
+      "version": "2.7.2",
+      "exclude": [
+        "javax.servlet:servlet-api",
+        "org.slf4j:slf4j-log4j12",
+        "io.netty:netty",
+      ]
+    }
+    "org.apache.hadoop:hadoop-mapreduce-client-core": {
+      "version": "2.7.2",
+      "exclude": [
+        "javax.servlet:servlet-api",
+        "org.slf4j:slf4j-log4j12",
+        "io.netty:netty",
+      ]
+    }
+    "org.apache.spark:spark-core_2.11": {
+      "version": "2.2.0",
+      "exclude": [
+        "com.fasterxml.jackson.module:jackson-module-scala_2.10",
+        "io.netty:netty",
+        "javax.servlet:ja,vax.servlet-api",
+        "log4j:log4j",
+        "org.scala-lang.modules:scala-xml_2.11",
+        "org.slf4j:jcl-over-slf4j",
+        "org.slf4j:slf4j-api",
+        "org.slf4j:slf4j-log4j12"
+      ]
+    }
+    "org.apache.spark:spark-launcher_2.11": {
+        "version": "2.2.0",
+        "exclude": [
+          "com.fasterxml.jackson.module:jackson-module-scala_2.10",
+          "io.netty:netty",
+          "javax.servlet:ja,vax.servlet-api",
+          "log4j:log4j",
+          "org.scala-lang.modules:scala-xml_2.11",
+          "org.slf4j:jcl-over-slf4j",
+          "org.slf4j:slf4j-api",
+          "org.slf4j:slf4j-log4j12"
+        ]
+    }
     "org.hamcrest:hamcrest": "2.2",
     "org.hamcrest:hamcrest-all": "1.3",
     "org.hamcrest:hamcrest-core": "1.3",
     "org.hamcrest:hamcrest-library": "1.3",
+    "org.javatuples:javatuples": "1.2",
     "org.mockito:mockito-core": "2.6.4",
+    "org.scala-lang:scala-library": "2.11.8",
     "org.slf4j:jcl-over-slf4j": "1.7.20",
     "org.slf4j:log4j-over-slf4j": "1.7.20",
+    # "org.slf4j:slf4j-api": "1.7.20",
     "org.slf4j:slf4j-api": "1.7.28",
     "org.slf4j:slf4j-simple": "1.7.20",
-    "org.yaml:snakeyaml":"1.25",
-    "org.zeroturnaround:zt-exec": "1.10"
+    "org.yaml:snakeyaml": "1.25",
+    "org.zeroturnaround:zt-exec": "1.10",
+  }
+  "org.apache.tinkerpop:gremlin-core": {
+    "version": "3.4.1",
+    "exclude": [
+      "org.slf4j:jcl-over-slf4j",
+      "org.slf4j:slf4j-log4j12",
+    ],
+  }
+  "org.apache.tinkerpop:hadoop-gremlin": {
+    "version": "3.4.1",
+    "exclude": [
+      "com.fasterxml.jackson.core:jackson-core",
+      "com.fasterxml.jackson.core:jackson-databind",
+      "com.sun.jersey:jersey-client",
+      "commons-logging:commons-logging",
+      "io.netty:netty",
+      "javax.servlet:javax.servlet-api",
+      "log4j:log4j",
+      "org.mortbay.jetty:jetty-util",
+      "org.slf4j:jcl-over-slf4j",
+      "org.slf4j:slf4j-log4j12",
+      "org.slf4j:slf4j-nop"
+    ]
+  }
+  "org.apache.tinkerpop:spark-gremlin": {
+    "version": "3.4.1",
+    "exclude": [
+      "com.fasterxml.jackson.core:jackson-annotations",
+      "com.fasterxml.jackson.core:jackson-core",
+      "com.fasterxml.jackson.core:jackson-databind",
+      "com.fasterxml.jackson.module:jackson-module-scala_2.10",
+      "io.netty:netty",
+      "javax.servlet:javax.servlet-api"
+    ]
+  }
+  "org.apache.tinkerpop:tinkergraph-gremlin": {
+    "version": "3.4.1",
+    "exclude": [
+      "org.slf4j:slf4j-log4j12",
+    ],
+  },
+  "org.zeroturnaround:zt-exec": {
+    "version": "1.10",
+    "exclude": [
+      "commons-io:commons-io",
+    ],
+  },
+  "com.datastax.oss:java-driver-core": {
+    "version": "4.3.0",
+    "exclude": [
+      "com.github.jnr:jnr-ffi",
+    ],
+  },
+  "com.datastax.oss:java-driver-query-builder": {
+    "version": "4.3.0",
+    "exclude": [
+      "com.github.jnr:jnr-ffi",
+    ],
+  }
 }

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -1,127 +1,125 @@
 artifacts = {
-    "ch.qos.logback:logback-classic": "1.2.3",
-    "ch.qos.logback:logback-core": "1.2.3",
-    "com.fasterxml.jackson.core:jackson-core": "2.9.10",
-    "com.fasterxml.jackson.core:jackson-databind": "2.9.10.1",
-    "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": "2.9.9",
-    "com.fasterxml.jackson.module:jackson-module-scala_2.11": "2.9.9",
-    "com.google.code.findbugs:annotations": "3.0.1",
-    "com.google.code.findbugs:jsr305": "2.0.2",
-    "com.google.guava:guava": "23.0",
-    "com.google.protobuf:protobuf-java": "3.5.1",
-    # "commons-cli:commons-cli": "1.3",
-    "commons-cli:commons-cli": "1.4",
-    "commons-collections:commons-collections": "3.2.1",
-    "commons-configuration:commons-configuration": "1.10",
-    "commons-io:commons-io": "2.3",
-    "commons-lang:commons-lang": "2.6",
-    "io.cucumber:cucumber-java": "5.1.3",
-    "io.cucumber:cucumber-junit": "5.1.3",
-    "io.grpc:grpc-api": "1.24.1",
-    "io.grpc:grpc-core": "1.24.1",
-    "io.grpc:grpc-netty": "1.24.1",
-    "io.grpc:grpc-protobuf": "1.24.1",
-    "io.grpc:grpc-stub": "1.24.1",
-    "io.grpc:grpc-testing": "1.24.1",
-    "io.netty:netty-all": "4.1.38.Final",
-    "io.netty:netty-codec-http2": "4.1.38.Final",
-    "io.netty:netty-handler": "4.1.38.Final",
-    "io.netty:netty-handler-proxy": "4.1.38.Final",
-    "io.netty:netty-tcnative-boringssl-static": "2.0.25.Final",
-    "io.vavr:vavr": "0.9.0",
-    "javax.annotation:javax.annotation-api": "1.3.2",
-    "javax.servlet:javax.servlet-api": "3.1.0",
-    "jline:jline": "2.12",
-    "junit:junit": "4.12",
-    "org.antlr:antlr4-runtime": "4.7.1",
-    "org.apache.cassandra:cassandra-all": {
-      "version": "3.11.3",
-      "exclude": [
-        "ch.qos.logback:logback-classic",
-        "ch.qos.logback:logback-core",
-        "it.unimi.dsi:fastutil",
-        "com.addthis.metrics:reporter-config3", # include this if we need to debug cassandra
-        "org.eclipse.jdt.core.compiler:ecj",
-      ]
-    },
-    "org.apache.cassandra:cassandra-thrift": {
-      "version": "3.11.3",
-      "exclude": [
-        "ch.qos.logback:logback-classic",
-        "ch.qos.logback:logback-core",
-        "it.unimi.dsi:fastutil",
-      ]
-    },
-    "org.apache.commons:commons-csv": "1.7",
-    # "org.apache.commons:commons-lang3": "3.3.1",
-    "org.apache.commons:commons-lang3": "3.9",
-    "org.apache.commons:commons-math3": "3.6.1",
-    "org.apache.hadoop:hadoop-annotations": "2.7.2",
-    "org.apache.thrift:libthrift": "0.9.2",
-    "org.apache.hadoop:hadoop-common": {
-      "version": "2.7.2",
-      "exclude": [
-        "javax.servlet:servlet-api",
-        "org.slf4j:slf4j-log4j12",
-        "io.netty:netty",
-      ]
-    }
-    "org.apache.hadoop:hadoop-mapreduce-client-core": {
-      "version": "2.7.2",
-      "exclude": [
-        "javax.servlet:servlet-api",
-        "org.slf4j:slf4j-log4j12",
-        "io.netty:netty",
-      ]
-    }
-    "org.apache.spark:spark-core_2.11": {
-      "version": "2.2.0",
-      "exclude": [
-        "com.fasterxml.jackson.module:jackson-module-scala_2.10",
-        "io.netty:netty",
-        "javax.servlet:ja,vax.servlet-api",
-        "log4j:log4j",
-        "org.scala-lang.modules:scala-xml_2.11",
-        "org.slf4j:jcl-over-slf4j",
-        "org.slf4j:slf4j-api",
-        "org.slf4j:slf4j-log4j12"
-      ]
-    }
-    "org.apache.spark:spark-launcher_2.11": {
-        "version": "2.2.0",
-        "exclude": [
-          "com.fasterxml.jackson.module:jackson-module-scala_2.10",
-          "io.netty:netty",
-          "javax.servlet:ja,vax.servlet-api",
-          "log4j:log4j",
-          "org.scala-lang.modules:scala-xml_2.11",
-          "org.slf4j:jcl-over-slf4j",
-          "org.slf4j:slf4j-api",
-          "org.slf4j:slf4j-log4j12"
-        ]
-    }
-    "org.hamcrest:hamcrest": "2.2",
-    "org.hamcrest:hamcrest-all": "1.3",
-    "org.hamcrest:hamcrest-core": "1.3",
-    "org.hamcrest:hamcrest-library": "1.3",
-    "org.javatuples:javatuples": "1.2",
-    "org.mockito:mockito-core": "2.6.4",
-    "org.scala-lang:scala-library": "2.11.8",
-    "org.slf4j:jcl-over-slf4j": "1.7.20",
-    "org.slf4j:log4j-over-slf4j": "1.7.20",
-    # "org.slf4j:slf4j-api": "1.7.20",
-    "org.slf4j:slf4j-api": "1.7.28",
-    "org.slf4j:slf4j-simple": "1.7.20",
-    "org.yaml:snakeyaml": "1.25",
-    "org.zeroturnaround:zt-exec": "1.10",
-  }
+  "ch.qos.logback:logback-classic": "1.2.3",
+  "ch.qos.logback:logback-core": "1.2.3",
+  "com.fasterxml.jackson.core:jackson-core": "2.9.10",
+  "com.fasterxml.jackson.core:jackson-databind": "2.9.10.1",
+  "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": "2.9.9",
+  "com.fasterxml.jackson.module:jackson-module-scala_2.11": "2.9.9",
+  "com.google.code.findbugs:annotations": "3.0.1",
+  "com.google.code.findbugs:jsr305": "2.0.2",
+  "com.google.guava:guava": "23.0",
+  "com.google.protobuf:protobuf-java": "3.5.1",
+  # "commons-cli:commons-cli": "1.3",
+  "commons-cli:commons-cli": "1.4",
+  "commons-collections:commons-collections": "3.2.1",
+  "commons-configuration:commons-configuration": "1.10",
+  "commons-io:commons-io": "2.3",
+  "commons-lang:commons-lang": "2.6",
+  "io.cucumber:cucumber-java": "5.1.3",
+  "io.cucumber:cucumber-junit": "5.1.3",
+  "io.grpc:grpc-api": "1.24.1",
+  "io.grpc:grpc-core": "1.24.1",
+  "io.grpc:grpc-netty": "1.24.1",
+  "io.grpc:grpc-protobuf": "1.24.1",
+  "io.grpc:grpc-stub": "1.24.1",
+  "io.grpc:grpc-testing": "1.24.1",
+  "io.netty:netty-all": "4.1.38.Final",
+  "io.netty:netty-codec-http2": "4.1.38.Final",
+  "io.netty:netty-handler": "4.1.38.Final",
+  "io.netty:netty-handler-proxy": "4.1.38.Final",
+  "io.netty:netty-tcnative-boringssl-static": "2.0.25.Final",
+  "io.vavr:vavr": "0.9.0",
+  "javax.annotation:javax.annotation-api": "1.3.2",
+  "javax.servlet:javax.servlet-api": "3.1.0",
+  "jline:jline": "2.12",
+  "junit:junit": "4.12",
+  "org.antlr:antlr4-runtime": "4.7.1",
+  "org.apache.cassandra:cassandra-all": {
+    "version": "3.11.3",
+    "exclude": [
+      "ch.qos.logback:logback-classic",
+      "ch.qos.logback:logback-core",
+      "it.unimi.dsi:fastutil",
+      "com.addthis.metrics:reporter-config3", # include this if we need to debug cassandra
+      "org.eclipse.jdt.core.compiler:ecj",
+    ]
+  },
+  "org.apache.cassandra:cassandra-thrift": {
+    "version": "3.11.3",
+    "exclude": [
+      "ch.qos.logback:logback-classic",
+      "ch.qos.logback:logback-core",
+      "it.unimi.dsi:fastutil",
+    ]
+  },
+  "org.apache.commons:commons-csv": "1.7",
+  # "org.apache.commons:commons-lang3": "3.3.1",
+  "org.apache.commons:commons-lang3": "3.9",
+  "org.apache.commons:commons-math3": "3.6.1",
+  "org.apache.hadoop:hadoop-annotations": "2.7.2",
+  "org.apache.thrift:libthrift": "0.9.2",
+  "org.apache.hadoop:hadoop-common": {
+    "version": "2.7.2",
+    "exclude": [
+      "javax.servlet:servlet-api",
+      "org.slf4j:slf4j-log4j12",
+      "io.netty:netty",
+    ]
+  },
+  "org.apache.hadoop:hadoop-mapreduce-client-core": {
+    "version": "2.7.2",
+    "exclude": [
+      "javax.servlet:servlet-api",
+      "org.slf4j:slf4j-log4j12",
+      "io.netty:netty",
+    ]
+  },
+  "org.apache.spark:spark-core_2.11": {
+    "version": "2.2.0",
+    "exclude": [
+      "com.fasterxml.jackson.module:jackson-module-scala_2.10",
+      "io.netty:netty",
+      "javax.servlet:ja,vax.servlet-api",
+      "log4j:log4j",
+      "org.scala-lang.modules:scala-xml_2.11",
+      "org.slf4j:jcl-over-slf4j",
+      "org.slf4j:slf4j-api",
+      "org.slf4j:slf4j-log4j12"
+    ]
+  },
+  "org.apache.spark:spark-launcher_2.11": {
+    "version": "2.2.0",
+    "exclude": [
+      "com.fasterxml.jackson.module:jackson-module-scala_2.10",
+      "io.netty:netty",
+      "javax.servlet:ja,vax.servlet-api",
+      "log4j:log4j",
+      "org.scala-lang.modules:scala-xml_2.11",
+      "org.slf4j:jcl-over-slf4j",
+      "org.slf4j:slf4j-api",
+      "org.slf4j:slf4j-log4j12"
+    ]
+  },
+  "org.hamcrest:hamcrest": "2.2",
+  "org.hamcrest:hamcrest-all": "1.3",
+  "org.hamcrest:hamcrest-core": "1.3",
+  "org.hamcrest:hamcrest-library": "1.3",
+  "org.javatuples:javatuples": "1.2",
+  "org.mockito:mockito-core": "2.6.4",
+  "org.scala-lang:scala-library": "2.11.8",
+  "org.slf4j:jcl-over-slf4j": "1.7.20",
+  "org.slf4j:log4j-over-slf4j": "1.7.20",
+  # "org.slf4j:slf4j-api": "1.7.20",
+  "org.slf4j:slf4j-api": "1.7.28",
+  "org.slf4j:slf4j-simple": "1.7.20",
+  "org.yaml:snakeyaml": "1.25",
   "org.apache.tinkerpop:gremlin-core": {
     "version": "3.4.1",
     "exclude": [
       "org.slf4j:jcl-over-slf4j",
-      "org.slf4j:slf4j-log4j12",
+      "org.slf4j:slf4j-log4j12"
     ],
-  }
+  },
   "org.apache.tinkerpop:hadoop-gremlin": {
     "version": "3.4.1",
     "exclude": [
@@ -137,7 +135,7 @@ artifacts = {
       "org.slf4j:slf4j-log4j12",
       "org.slf4j:slf4j-nop"
     ]
-  }
+  },
   "org.apache.tinkerpop:spark-gremlin": {
     "version": "3.4.1",
     "exclude": [
@@ -148,7 +146,7 @@ artifacts = {
       "io.netty:netty",
       "javax.servlet:javax.servlet-api"
     ]
-  }
+  },
   "org.apache.tinkerpop:tinkergraph-gremlin": {
     "version": "3.4.1",
     "exclude": [
@@ -172,5 +170,5 @@ artifacts = {
     "exclude": [
       "com.github.jnr:jnr-ffi",
     ],
-  }
+  },
 }

--- a/library/maven/rules.bzl
+++ b/library/maven/rules.bzl
@@ -1,15 +1,16 @@
-load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:defs.bzl", rje_maven_install = "maven_install")
+load("@rules_jvm_external//:specs.bzl", rje_maven = "maven")
 load(":artifacts.bzl", artifacts_registered = "artifacts")
 
 def maven(artifacts_list):
-    for artifact in artifacts_list:
-        if artifact not in artifacts_registered.keys():
-            fail("'" + artifact + "' has not been declared in @graknlabs_dependencies")
+    for a in artifacts_list:
+        if a not in artifacts_registered.keys():
+            fail("'" + a + "' has not been declared in @graknlabs_dependencies")
     artifacts_selected = []
-    for artifact in artifacts_list:
-        version = artifacts_registered[artifact]
-        artifacts_selected.append(artifact + ":" + version)
-    maven_install(
+    for a in artifacts_list:
+        artifact = maven_artifact(a, artifacts_registered[a])
+        artifacts_selected.append(artifact)
+    rje_maven_install(
         artifacts = artifacts_selected,
         repositories = [
             "https://repo1.maven.org/maven2",
@@ -18,3 +19,25 @@ def maven(artifacts_list):
         strict_visibility = True,
         version_conflict_policy = "pinned"
     )
+
+def maven_artifact(artifact, artifact_info):
+    group, artifact_id = artifact.split(':')
+    if type(artifact_info) == type(' '):
+        artifact = rje_maven.artifact(
+            group = group,
+            artifact = artifact_id,
+            version = artifact_info,
+        )
+    elif type(artifact_info) == type({}):
+        exclusions = []
+        for e in artifact_info['exclude']:
+            exclusions.append(e)
+        artifact = rje_maven.artifact(
+            group = group,
+            artifact = artifact_id,
+            version = artifact_info['version'],
+            exclusions = exclusions
+        )
+    else:
+        fail("The info for '" + artifact + "' must either be a 'string' (eg., '1.8.1') or a 'dict' (eg., {'version': '1.8.1', 'exclude': ['org.slf4j:slf4j']})")
+    return artifact


### PR DESCRIPTION
We have supported excluding artifacts in `library/maven/artifacts.bzl`:

```
artifacts = {
   # add an artifact with version 1.2.3, without excluding any transitive dependencies
  "ch.qos.logback:logback-classic": "1.2.3",

   # add an artifact with version 1.10 and exclude "commons-io:commons-io"
  "org.zeroturnaround:zt-exec": { # 
    "version": "1.10",
    "exclude": [
      "commons-io:commons-io",
    ],
  }
}
```

Additionally, we've added more Maven dependencies used by various repositories across Grakn Labs