### PR TITLE
Add Picocli maven dependency

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -15,6 +15,7 @@ artifacts = {
   "commons-configuration:commons-configuration": "1.10",
   "commons-io:commons-io": "2.3",
   "commons-lang:commons-lang": "2.6",
+  "info.picocli:picocli": "4.3.2",
   "io.cucumber:cucumber-java": "5.1.3",
   "io.cucumber:cucumber-junit": "5.1.3",
   "io.grpc:grpc-api": "1.24.1",


### PR DESCRIPTION
We would like to use Picocli in our projects to do command line interfaces in a consistent way that supports subcommand hierarchies.

- Add Picocli maven dependency