### PR TITLE
Implement Maven's artifacts.snapshot update script

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,13 @@ load("//builder/java:deps.bzl", java_deps = "deps")
 java_deps()
 load("//library/maven:rules.bzl", "maven")
 
+# Load Kotlin
+load("//builder/kotlin:deps.bzl", kotlin_deps = "deps")
+kotlin_deps()
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+kotlin_repositories()
+kt_register_toolchains()
+
 # Load NodeJS
 load("//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()

--- a/builder/kotlin/deps.bzl
+++ b/builder/kotlin/deps.bzl
@@ -1,0 +1,10 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def deps():
+    http_archive(
+        name = "io_bazel_rules_kotlin",
+        urls = ["https://github.com/bazelbuild/rules_kotlin/archive/legacy-1.3.0.zip"],
+        type = "zip",
+        strip_prefix = "rules_kotlin-legacy-1.3.0",
+        sha256 = "4fd769fb0db5d3c6240df8a9500515775101964eebdf85a3f9f0511130885fde",
+    )

--- a/library/maven/BUILD
+++ b/library/maven/BUILD
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+
+kt_jvm_binary(
+    name = "update",
+    main_class = "library.maven.UpdateKt",
+    srcs = ["update.kt"],
+)

--- a/library/maven/update.kt
+++ b/library/maven/update.kt
@@ -1,0 +1,44 @@
+package library.maven
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+fun main() {
+    val baseDir = Paths.get(System.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    val snapshotCommand = listOf("bazel", "query", "@maven//...")
+    val snapshotFile = baseDir.resolve("dependencies").resolve("maven").resolve("snapshot")
+
+    println("-------------------------")
+    println("Regenerating a new '$snapshotFile' from WORKSPACE...")
+    val snapshotOld = if (snapshotFile.toFile().exists()) Files.readAllLines(snapshotFile).toSortedSet() else sortedSetOf()
+    val snapshotUpdateProc = ProcessBuilder().directory(baseDir.toFile()).command(snapshotCommand).start()
+    val snapshotNew = snapshotUpdateProc.inputStream
+            .use { inStr -> inStr.reader().readLines() }
+            .toSortedSet()
+    Files.write(snapshotFile, snapshotNew.joinToString(System.lineSeparator()).toByteArray())
+    if (snapshotUpdateProc.exitValue() != 0) {
+        throw RuntimeException("'$snapshotCommand' failed with exit code '${snapshotUpdateProc.exitValue()}'")
+    }
+
+    val added = snapshotNew.minus(snapshotOld)
+    val removed = snapshotOld.minus(snapshotNew)
+    println("DONE! '$snapshotFile' updated: ${added.count()} dependencies added, ${removed.count()} dependencies removed.")
+    print("Added dependencies:")
+    if (added.isNotEmpty()) {
+        println()
+        added.forEach { dep -> println(" - $dep") }
+    }
+    else {
+        println(" none.")
+    }
+
+    print("Removed dependencies:")
+    if (removed.isNotEmpty()) {
+        println()
+        removed.forEach { dep -> println(" - $dep") }
+    }
+    else {
+        println(" none.")
+    }
+    println("-------------------------")
+}

--- a/library/maven/update.kt
+++ b/library/maven/update.kt
@@ -31,7 +31,6 @@ fun main() {
     else {
         println(" none.")
     }
-
     print("Removed dependencies:")
     if (removed.isNotEmpty()) {
         println()


### PR DESCRIPTION
We have implemented a script to update Maven's `artifacts.snapshot` file.

Usage example:
```
$ bazel run @graknlabs_dependencies//library/maven:update

-------------------------
Regenerating a new '/Users/lolski/grakn.ai/graknlabs/grakn/dependencies/maven/snapshot' from WORKSPACE...
DONE! '/Users/lolski/grakn.ai/graknlabs/grakn/dependencies/maven/snapshot' updated: 4 dependencies added, 1 dependencies removed.
Added dependencies:
 - @maven//:com_boundary_high_scale_lib
 - @maven//:com_boundary_high_scale_lib_1_0_6
 - @maven//:com_github_jbellis_jamm
 - @maven//:org_ow2_asm_asm_5_0_4
Removed dependencies:
 - @maven//:io_dropwizard_metrics_metrics_jvm_3_1_2
-------------------------
```