### PR TITLE
Update deployment.properties

### DIFF
--- a/deployment.properties
+++ b/deployment.properties
@@ -17,6 +17,3 @@
 
 repo.github.organisation=graknlabs
 repo.github.repository=dependencies
-
-repo.distribution.snapshot=https://repo.grakn.ai/repository/distribution-snapshot/
-repo.distribution.release=https://repo.grakn.ai/repository/distribution/

--- a/distribution/deployment.properties
+++ b/distribution/deployment.properties
@@ -37,4 +37,7 @@ repo.rpm.release=https://repo.grakn.ai/repository/rpm/
 repo.distribution.snapshot=https://repo.grakn.ai/repository/distribution-snapshot/
 repo.distribution.release=https://repo.grakn.ai/repository/distribution/
 
+repo.distribution.snapshot=https://repo.grakn.ai/repository/distribution-snapshot/
+repo.distribution.release=https://repo.grakn.ai/repository/distribution/
+
 maven.packages=api,client-java,common,concept,console,daemon,grammar,grpc,java,,server


### PR DESCRIPTION
These URLs were meant to be in the re-usable deployment.properties file, which was moved in another PR that happened alongside the one that added these URLS.