### PR TITLE
Add artifact rules (moved from bazel-distribution)

### DIFF
--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -41,13 +41,13 @@ def _deploy_artifact_impl(ctx):
             "{version_file}": version_file.short_path,
             "{artifact_path}": ctx.file.target.short_path,
             "{artifact_group}": ctx.attr.artifact_group,
+            "{artifact_filename}": ctx.attr.artifact_filename,
             "{release_repository_url}": ctx.attr._release_repository_url,
             "{snapshot_repository_url}": ctx.attr._snapshot_repository_url,
         },
     )
     files = [
         ctx.file.target,
-        ctx.file.deployment_properties,
         version_file,
         ctx.file._common_py
     ]
@@ -74,11 +74,6 @@ deploy_artifact = rule(
             mandatory = True,
             doc = "File to deploy to repo",
         ),
-        "deployment_properties": attr.label(
-            allow_single_file = True,
-            mandatory = True,
-            doc = "File containing repository url by `repo.artifact` key",
-        ),
         "version_file": attr.label(
             allow_single_file = True,
             doc = """
@@ -91,6 +86,10 @@ deploy_artifact = rule(
             mandatory = True,
             doc = "The group of the artifact.",
         ),
+        "artifact_name": attr.string(
+            doc = "The artifact filename, automatic from the target file if not specified",
+            default = '',
+        )
         "_deploy_script": attr.label(
             allow_single_file = True,
             default = "//distribution/artifact/templates:deploy.py",
@@ -99,10 +98,10 @@ deploy_artifact = rule(
             allow_single_file = True,
             default = "graknlabs_bazel_distribution//common:common.py",
         ),
-        "_release_repository_url": attr.string(
+        "release_repository_url": attr.string(
             default = GRAKNLABS_ARTIFACT_RELEASE_REPOSITORY_URL,
         ),
-        "_snapshot_repository_url": attr.string(
+        "snapshot_repository_url": attr.string(
             default = GRAKNLABS_ARTIFACT_SNAPSHOT_REPOSITORY_URL,
         ),
     },

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def _deploy_artifact_impl(ctx):
+    _deploy_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
+
+    version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
+    version = ctx.var.get('version', '0.0.0')
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [version_file],
+        command = "echo {} > {}".format(version, version_file.path),
+    )
+    
+    ctx.actions.expand_template(
+        template = ctx.file._deploy_script,
+        output = _deploy_script,
+        substitutions = {
+            "{version_file}": version_file.short_path,
+            "{artifact_path}": ctx.file.target.short_path,
+            "{artifact_group}": ctx.attr.artifact_group,
+        },
+    )
+    files = [
+        ctx.file.target,
+        ctx.file.deployment_properties,
+        version_file,
+        ctx.file._common_py
+    ]
+
+    symlinks = {
+        "deployment.properties": ctx.file.deployment_properties,
+        "common.py": ctx.file._common_py,
+        'VERSION': version_file,
+    }
+
+    return DefaultInfo(
+        executable = _deploy_script,
+        runfiles = ctx.runfiles(
+            files = files,
+            symlinks = symlinks,
+        ),
+    )
+
+
+deploy_artifact = rule(
+    attrs = {
+        "target": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File to deploy to repo",
+        ),
+        "deployment_properties": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing repository url by `repo.artifact` key",
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            doc = """
+            File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
+            """,
+        ),
+        "artifact_group": attr.string(
+            mandatory = True,
+            doc = "The group of the artifact.",
+        ),
+        "_deploy_script": attr.label(
+            allow_single_file = True,
+            default = "//distribution/artifact/templates:deploy.py",
+        ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "graknlabs_bazel_distribution//common:common.py",
+        ),
+    },
+    executable = True,
+    implementation = _deploy_artifact_impl,
+    doc = "Deploy archive target into a raw repo",
+)
+
+def artifact_file(name,
+                  repository_url,
+                  group_name,
+                  file_name,
+                  commit = None,
+                  tag = None,
+                  sha = None,
+                  tags = []):
+
+    repo_name = "artifact" if tag != None else "artifact-snapshot"
+    version = tag if tag != None else commit
+    versiontype = "tag" if tag != None else "commit"
+
+    http_file(
+        name = name,
+        urls = ["{}/{}/{}/{}/{}/{}".format(repository_url, repo_name, group_name, version, file_name)],
+        downloaded_file_path = file_name,
+        sha = sha,
+        tags = tags + ["{}={}".format(versiontype, version)]
+    )

--- a/distribution/artifact/templates/BUILD
+++ b/distribution/artifact/templates/BUILD
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+exports_files(["deploy.py"])

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -27,12 +27,6 @@ import subprocess as sp
 import sys
 from posixpath import join as urljoin
 
-# usual importing is not possible because
-# this script and module with common functions
-# are at different directory levels in sandbox
-from runpy import run_path
-parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
-
 
 def upload(url, username, password, local_fn, remote_fn):
     upload_status_code = sp.check_output([
@@ -85,7 +79,10 @@ artifact_name = os.path.basename('{artifact_path}')
 filename = '{artifact_group}/{version}/{artifact_name}'.format(
     version=version, artifact_name=artifact_name)
 
-deployment_properties = parse_deployment_properties('deployment.properties')
-artifact_url = deployment_properties['repo.artifact.' + repo_type]
+repository_url = None
+if repo_type == 'release':
+    repository_url = '{release_repository_url}'
+else:
+    repository_url = '{snapshot_repository_url}'
 
-upload(artifact_url, username, password, '{artifact_path}', filename)
+upload(repository_url, username, password, '{artifact_path}', filename)

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -76,13 +76,14 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
 
 filename = '{artifact_filename}'
 if filename == '':
-    filename = '{artifact_group}/{version}/{artifact_name}'.format(
-        version=version, artifact_name=os.path.basename('{artifact_path}'))
+    filename = os.path.basename('{artifact_path}')
 
-repository_url = None
+base_url = None
 if repo_type == 'release':
-    repository_url = '{release_repository_url}'
+    base_url = '{release_repository_url}'
 else:
-    repository_url = '{snapshot_repository_url}'
+    base_url = '{snapshot_repository_url}'
 
-upload(repository_url, username, password, '{artifact_path}', filename)
+dir_url = '{base_url}/{artifact_group}/{version}'.format(version=version, base_url=base_url)
+
+upload(dir_url, username, password, '{artifact_path}', filename)

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import print_function
+
+import os
+import re
+import subprocess as sp
+import sys
+from posixpath import join as urljoin
+
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
+
+
+def upload(url, username, password, local_fn, remote_fn):
+    upload_status_code = sp.check_output([
+        'curl', '--silent', '--output', '/dev/stderr',
+        '--write-out', '%{http_code}',
+        '-u', '{}:{}'.format(username, password),
+        '--upload-file', local_fn,
+        urljoin(url, remote_fn)
+    ]).decode().strip()
+
+    if upload_status_code != '201':
+        raise Exception('upload of {} failed, got HTTP status code {}'.format(
+            local_fn, upload_status_code))
+
+
+if len(sys.argv) != 2:
+    raise ValueError('Should pass only <snapshot|release> as arguments')
+
+_, repo_type = sys.argv
+
+username, password = os.getenv('DEPLOY_ARTIFACT_USERNAME'), os.getenv('DEPLOY_ARTIFACT_PASSWORD')
+
+if not username:
+    raise ValueError('Error: username should be passed via $DEPLOY_ARTIFACT_USERNAME env variable')
+
+if not password:
+    raise ValueError('Error: password should be passed via $DEPLOY_ARTIFACT_PASSWORD env variable')
+
+version = open("{version_file}", "r").read().strip()
+
+repo_type_snapshot = 'snapshot'
+version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
+repo_type_release = 'release'
+version_release_regex = '^[0-9]+.[0-9]+.[0-9]+$'
+
+if repo_type not in [repo_type_snapshot, repo_type_release]:
+    raise ValueError("Invalid repository type: {}. It should be one of these: {}"
+                     .format(repo_type, [repo_type_snapshot, repo_type_release]))
+if repo_type == 'snapshot' and len(re.findall(version_snapshot_regex, version)) == 0:
+    raise ValueError('Invalid version: {}. An artifact uploaded to a {} repository '
+                     'must have a version which complies to this regex: {}'
+                     .format(version, repo_type, version_snapshot_regex))
+if repo_type == 'release' and len(re.findall(version_release_regex, version)) == 0:
+    raise ValueError('Invalid version: {}. An artifact uploaded to a {} repository '
+                     'must have a version which complies to this regex: {}'
+                     .format(version, repo_type, version_snapshot_regex))
+
+artifact_name = os.path.basename('{artifact_path}')
+
+filename = '{artifact_group}/{version}/{artifact_name}'.format(
+    version=version, artifact_name=artifact_name)
+
+deployment_properties = parse_deployment_properties('deployment.properties')
+artifact_url = deployment_properties['repo.artifact.' + repo_type]
+
+upload(artifact_url, username, password, '{artifact_path}', filename)

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -74,10 +74,10 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
                      'must have a version which complies to this regex: {}'
                      .format(version, repo_type, version_snapshot_regex))
 
-artifact_name = os.path.basename('{artifact_path}')
-
-filename = '{artifact_group}/{version}/{artifact_name}'.format(
-    version=version, artifact_name=artifact_name)
+filename = '{artifact_filename}'
+if filename == '':
+    filename = '{artifact_group}/{version}/{artifact_name}'.format(
+        version=version, artifact_name=os.path.basename('{artifact_path}'))
 
 repository_url = None
 if repo_type == 'release':

--- a/distribution/deployment.properties
+++ b/distribution/deployment.properties
@@ -34,10 +34,4 @@ repo.npm.snapshot=https://repo.grakn.ai/repository/npm-snapshot/
 repo.rpm.snapshot=https://repo.grakn.ai/repository/rpm-snapshot/
 repo.rpm.release=https://repo.grakn.ai/repository/rpm/
 
-repo.distribution.snapshot=https://repo.grakn.ai/repository/distribution-snapshot/
-repo.distribution.release=https://repo.grakn.ai/repository/distribution/
-
-repo.distribution.snapshot=https://repo.grakn.ai/repository/distribution-snapshot/
-repo.distribution.release=https://repo.grakn.ai/repository/distribution/
-
 maven.packages=api,client-java,common,concept,console,daemon,grammar,grpc,java,,server


### PR DESCRIPTION
We want to move the artifact distribution rules from bazel-distribution to here because they need to be very graknlabs specific.