### PR TITLE
Add version interpolation to artifact rules

### DIFF
--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -109,6 +109,7 @@ deploy_artifact = rule(
     doc = "Deploy archive target into a raw repo",
 )
 
+
 def artifact_file(name,
                   group_name,
                   artifact_name,
@@ -118,11 +119,25 @@ def artifact_file(name,
                   release_repository_url = GRAKNLABS_ARTIFACT_RELEASE_REPOSITORY_URL,
                   snapshot_repository_url = GRAKNLABS_ARTIFACT_SNAPSHOT_REPOSITORY_URL,
                   tags = []):
+    """Macro to assist depending on a deployed artifact by generating urls for http_file.
+
+    Args:
+        name: Target name.
+        group_name: Repo group name used to deploy artifact.
+        artifact_name: Artifact name, use {version} to interpolate the version from tag/commit.
+        commit: Commit sha, for when this was used as the version for upload.
+        tag: Git tag, for when this was used as the version for upload.
+        release_repository_url: The base repository URL for tag releases.
+        snapshot_repository_url: The base repository URL for snapshot/commit sha releases.
+        tags: Tags to forward onto the http_file rule.
+    """
 
     version = tag if tag != None else commit
     versiontype = "tag" if tag != None else "commit"
 
-    repository_url = release_repository_url if versiontype == "tag" else snapshot_repository_url
+    repository_url = release_repository_url if tag != None else snapshot_repository_url
+
+    artifact_name = artifact_name.format(version = version)
 
     http_file(
         name = name,

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -113,6 +113,7 @@ deploy_artifact = rule(
 def artifact_file(name,
                   group_name,
                   artifact_name,
+                  downloaded_file_path = None,
                   commit = None,
                   tag = None,
                   sha = None,
@@ -125,6 +126,7 @@ def artifact_file(name,
         name: Target name.
         group_name: Repo group name used to deploy artifact.
         artifact_name: Artifact name, use {version} to interpolate the version from tag/commit.
+        downloaded_file_path: Equivalent to http_file downloaded_file_path, defaults to artifact_name, includes {version} interpolation.
         commit: Commit sha, for when this was used as the version for upload.
         tag: Git tag, for when this was used as the version for upload.
         release_repository_url: The base repository URL for tag releases.
@@ -137,7 +139,11 @@ def artifact_file(name,
 
     repository_url = release_repository_url if tag != None else snapshot_repository_url
 
+    if downloaded_file_path == None:
+        downloaded_file_path = artifact_name
+
     artifact_name = artifact_name.format(version = version)
+    downloaded_file_path = downloaded_file_path.format(version = version)
 
     http_file(
         name = name,

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -78,6 +78,8 @@ filename = '{artifact_filename}'
 if filename == '':
     filename = os.path.basename('{artifact_path}')
 
+filename = filename.format(version = version)
+
 base_url = None
 if repo_type == 'release':
     base_url = '{release_repository_url}'


### PR DESCRIPTION
We need to be able to publish artifacts with versioned filenames and including help for this logic in the `artifact` rules will significantly improve development experience. The solution we've gone for is to allow the version to be interpolated into the artifact filename, since this can be the same on both sides of the rule (deploy/depend), works in static rules (no file dependencies), is very flexible on filename format and has very clear visibility on what the resulting filename will look like.