### PR TITLE
Add extract script generation macro

### DIFF
--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -153,7 +153,7 @@ def artifact_file(name,
         tags = tags + ["{}={}".format(versiontype, version)]
     )
 
-def generate_extract_artifact_script(name,
+def artifact_extractor_generator(name,
                                      target,
                                      strip_components = 2):
     """Macro to assist extracting an artifact from command line (for CI).

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -152,3 +152,21 @@ def artifact_file(name,
         sha = sha,
         tags = tags + ["{}={}".format(versiontype, version)]
     )
+
+def generate_extract_artifact_script(name,
+                                     target,
+                                     strip_components = 2):
+    """Macro to assist extracting an artifact from command line (for CI).
+
+    Args:
+        name: Target name.
+        target: Repo group name used to deploy artifact.
+        strip_components: tar --strip-components setting, default is 2 to strip version.
+    """
+
+    native.genrule(
+        name = name,
+        srcs = [target],
+        outs = [name + ".sh"],
+        cmd = "echo \"mkdir -p \$$1 && tar -xzf \$$(bazel info execution_root)/$(location {}) -C \$$1 --strip-components={}\" > $@".format(target, strip_components),
+    )

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -109,6 +109,7 @@ deploy_artifact = rule(
     doc = "Deploy archive target into a raw repo",
 )
 
+
 def artifact_file(name,
                   group_name,
                   artifact_name,
@@ -118,11 +119,25 @@ def artifact_file(name,
                   release_repository_url = GRAKNLABS_ARTIFACT_RELEASE_REPOSITORY_URL,
                   snapshot_repository_url = GRAKNLABS_ARTIFACT_SNAPSHOT_REPOSITORY_URL,
                   tags = []):
+    """Macro to assist depending on a deployed artifact by generating urls for http_file.
+
+    Args:
+        name: Target name.
+        group_name: Repo group name used to deploy artifact.
+        artifact_name: Artifact name, use {version} to interpolate the version from tag/commit.
+        commit: Commit sha, for when this was used as the version for upload.
+        tag: Git tag, for when this was used as the version for upload.
+        release_repository_url: The base repository URL for tag releases.
+        snapshot_repository_url: The base repository URL for snapshot/commit sha releases.
+        tags: Tags to forward onto the http_file rule.
+    """
 
     version = tag if tag != None else commit
     versiontype = "tag" if tag != None else "commit"
 
-    repository_url = release_repository_url if versiontype == "tag" else snapshot_repository_url
+    repository_url = release_repository_url if tag != None else snapshot_repository_url
+
+    artifact_name = artifact_name.format(version = version)
 
     http_file(
         name = name,

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -113,6 +113,7 @@ deploy_artifact = rule(
 def artifact_file(name,
                   group_name,
                   artifact_name,
+                  downloaded_file_path = None,
                   commit = None,
                   tag = None,
                   sha = None,
@@ -125,6 +126,7 @@ def artifact_file(name,
         name: Target name.
         group_name: Repo group name used to deploy artifact.
         artifact_name: Artifact name, use {version} to interpolate the version from tag/commit.
+        downloaded_file_path: Equivalent to http_file downloaded_file_path, defaults to artifact_name, includes {version} interpolation.
         commit: Commit sha, for when this was used as the version for upload.
         tag: Git tag, for when this was used as the version for upload.
         release_repository_url: The base repository URL for tag releases.
@@ -137,7 +139,11 @@ def artifact_file(name,
 
     repository_url = release_repository_url if tag != None else snapshot_repository_url
 
+    if downloaded_file_path == None:
+        downloaded_file_path = artifact_name
+
     artifact_name = artifact_name.format(version = version)
+    downloaded_file_path = downloaded_file_path.format(version = version)
 
     http_file(
         name = name,

--- a/distribution/artifact/templates/deploy.py
+++ b/distribution/artifact/templates/deploy.py
@@ -78,6 +78,8 @@ filename = '{artifact_filename}'
 if filename == '':
     filename = os.path.basename('{artifact_path}')
 
+filename = filename.format(version = version)
+
 base_url = None
 if repo_type == 'release':
     base_url = '{release_repository_url}'


### PR DESCRIPTION
We need to be able to extract an artifact depended on via artifact rules on the command line in CI. This is tricky without some bazel magic, so we've created a macro that can use bazel specific logic to generate an executable script that performs this logic for us. This plays by all of bazel's rules to avoid non-hermetic builds.