### PR TITLE
Add JMH benchmarking library and rules

### DIFF
--- a/library/jmh/BUILD
+++ b/library/jmh/BUILD
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/library/jmh/artifacts.bzl
+++ b/library/jmh/artifacts.bzl
@@ -1,0 +1,4 @@
+artifacts = [
+    "org.openjdk.jmh:jmh-core",
+    "org.openjdk.jmh:jmh-generator-annprocess",
+]

--- a/library/jmh/rules.bzl
+++ b/library/jmh/rules.bzl
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+def java_jmh_benchmarks(name, srcs, deps=[], tags=[], plugins=[], **kwargs):
+    """Build runnables JMH benchmarks.
+    This rule builds a runnable target for one or more JMH benchmarks
+    specified as srcs. It takes the same arguments as java_binary,
+    except for main_class.
+    """
+    plugin_name = "_{}_jmh_annotation_processor".format(name)
+    native.java_plugin(
+        name = plugin_name,
+        deps = ["@maven//:org_openjdk_jmh_jmh_generator_annprocess"],
+        processor_class = "org.openjdk.jmh.generators.BenchmarkProcessor",
+        visibility = ["//visibility:private"],
+        tags = tags,
+    )
+    native.java_binary(
+        name = name,
+        srcs = srcs,
+        main_class = "org.openjdk.jmh.Main",
+        deps = deps + ["@maven//:org_openjdk_jmh_jmh_core"],
+        plugins = plugins + [plugin_name],
+        tags = tags,
+        **kwargs
+    )

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -195,6 +195,8 @@ artifacts = {
     "org.javatuples:javatuples": "1.2",
     "org.kohsuke:github-api": "1.101",
     "org.mockito:mockito-core": "2.6.4",
+    "org.openjdk.jmh:jmh-core": "1.23",
+    "org.openjdk.jmh:jmh-generator-annprocess": "1.23",
     "org.rocksdb:rocksdbjni": "6.8.1",
     "org.scala-lang:scala-library": "2.12.10",
     "org.sharegov:mjson": "1.4.1",


### PR DESCRIPTION
JMH is a common tool for benchmarking Java applications, so we are adding it to this repo to make it available to our other repos.