### PR TITLE
Add jeromq maven dependency.

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -205,6 +205,7 @@ artifacts = {
     "org.slf4j:slf4j-api": "1.7.28",
     "org.slf4j:slf4j-simple": "1.7.20",
     "org.yaml:snakeyaml": "1.25",
+    "org.zeromq:jeromq": "0.5.2",
     "org.zeroturnaround:zt-exec": {
         "exclude": ["commons-io:commons-io"],
         "version": "1.10",


### PR DESCRIPTION
We are planning to use ZeroMQ (implemented with the JeroMQ library for Java) as our cluster fabric (node to node networking). This PR adds the dependency to make it available to downstream repositories.