### PR TITLE
Update our maven repository URLs

### DIFF
--- a/library/maven/rules.bzl
+++ b/library/maven/rules.bzl
@@ -20,7 +20,8 @@ def maven(artifacts_list, overrides={}):
         artifacts = artifacts_selected,
         repositories = [
             "https://repo1.maven.org/maven2",
-            "http://maven.grakn.ai/nexus/content/repositories/snapshots"
+            "https://repo.grakn.ai/repository/maven",
+            "https://repo.grakn.ai/repository/maven-snapshot",
         ],
         strict_visibility = True,
         version_conflict_policy = "pinned"


### PR DESCRIPTION
We still have old maven repository URLs in our maven rules. This will always fail if we try to fall back to it.