### PR TITLE
Remove bazel-deps and bazel-common

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,7 @@ load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 antlr_dependencies()
 
 # Load Bazel
-load("//builder/bazel:deps.bzl","bazel_common", "bazel_deps", "bazel_toolchain")
-bazel_common()
-bazel_deps()
+load("//builder/bazel:deps.bzl", "bazel_toolchain")
 bazel_toolchain()
 
 # Load gRPC

--- a/builder/bazel/BUILD
+++ b/builder/bazel/BUILD
@@ -15,10 +15,3 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
-java_binary(
-    name = "bazel-deps",
-    main_class = "com.github.johnynek.bazel_deps.ParseProject",
-    visibility = ["//visibility:public"],
-    runtime_deps = ["@bazel_deps//jar:jar"],
-)

--- a/builder/bazel/deps.bzl
+++ b/builder/bazel/deps.bzl
@@ -16,15 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def bazel_common():
-    git_repository(
-        name="com_github_google_bazel_common",
-        remote="https://github.com/graknlabs/bazel-common",
-        commit="5cf83ccbb4b184f282380fe2c1f47b13336ffcdd",
-    )
 
 def bazel_toolchain():
     http_archive(
@@ -34,10 +27,4 @@ def bazel_toolchain():
       urls = [
         "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.0.1/bazel-toolchains-3.0.1.tar.gz",
       ],
-    )
-
-def bazel_deps():
-    http_jar(
-        name = "bazel_deps",
-        urls = ["https://github.com/graknlabs/bazel-deps/releases/download/0.3/grakn-bazel-deps-0.3.jar"],
     )


### PR DESCRIPTION
`@com_github_google_bazel_common` and `bazel-deps` are now universally not used, so they need to be removed