### PR TITLE
Use new name for file with Bazel workspace dependencies

### DIFF
--- a/tool/release/validate-deps.py
+++ b/tool/release/validate-deps.py
@@ -3,7 +3,7 @@ import sys
 
 if __name__ == '__main__':
     print('Further usage of this script is discouraged. Please use release_validate_deps_test from //ci:rules.bzl instead')
-    deps_path = os.path.join('dependencies', 'graknlabs', 'dependencies.bzl')
+    deps_path = os.path.join('dependencies', 'graknlabs', 'repositories.bzl')
     snapshot_dependencies = []
     with open(os.path.join(os.getenv("BUILD_WORKSPACE_DIRECTORY"), deps_path)) as deps_file_object:
         deps_content = deps_file_object.read().splitlines()


### PR DESCRIPTION
We've in process of moving `dependencies/graknlabs/dependencies.bzl` to `dependencies/graknlabs/repositories.bzl` so `@graknlabs_dependencies//tool/release:validate-deps` need to be tweaked accordingly