### PR TITLE
Tweak tool/bazelinstall/rbe.sh

### DIFF
--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -35,6 +35,7 @@ if [[ -n "$BAZEL_BUILDBUDDY_CERT" && -n "$BAZEL_BUILDBUDDY_KEY" ]]; then
     echo "Installing BuildBuddy credential..."
     BAZEL_BUILDBUDDY_CREDENTIAL=/opt/.credentials/
     echo "A BuildBuddy credential is found and will be saved to $BAZEL_BUILDBUDDY_CREDENTIAL. Targets will be built and tested remotely."
+    sudo mkdir -p $BAZEL_BUILDBUDDY_CREDENTIAL && sudo chmod a+rwx $BAZEL_BUILDBUDDY_CREDENTIAL
     echo $BAZEL_BUILDBUDDY_CERT | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-cert.pem"
     echo $BAZEL_BUILDBUDDY_KEY | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-key.pem"
     echo "The RBE credential has been installed!"

--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -31,13 +31,10 @@ function install_dependencies() {
     fi
 }
 
-cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
-
 if [[ -n "$BAZEL_BUILDBUDDY_CERT" && -n "$BAZEL_BUILDBUDDY_KEY" ]]; then
     echo "Installing BuildBuddy credential..."
-    BAZEL_BUILDBUDDY_CREDENTIAL=/home/circleci/.credentials/
+    BAZEL_BUILDBUDDY_CREDENTIAL=/opt/.credentials/
     echo "A BuildBuddy credential is found and will be saved to $BAZEL_BUILDBUDDY_CREDENTIAL. Targets will be built and tested remotely."
-    mkdir -p $BAZEL_BUILDBUDDY_CREDENTIAL
     echo $BAZEL_BUILDBUDDY_CERT | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-cert.pem"
     echo $BAZEL_BUILDBUDDY_KEY | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-key.pem"
     echo "The RBE credential has been installed!"


### PR DESCRIPTION
* BuildBuddy credential path is adjusted to be `/opt/.credentials`
* `pyenv` (on Grabl) no longer needs an additional `git pull` command