### PR TITLE
Restore pyenv cloning in tools/bazelinstall/rbe.sh

### DIFF
--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -31,6 +31,7 @@ function install_dependencies() {
     fi
 }
 
+cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
 if [[ -n "$BAZEL_BUILDBUDDY_CERT" && -n "$BAZEL_BUILDBUDDY_KEY" ]]; then
     echo "Installing BuildBuddy credential..."
     BAZEL_BUILDBUDDY_CREDENTIAL=/opt/.credentials/


### PR DESCRIPTION
Fixes this CircleCI error:

>python-build: definition not found: 3.6.10
>See all available versions with `pyenv install --list'.
>If the version you need is missing, try upgrading pyenv:
>    cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -