### PR TITLE
Make pyenv-related command cross-compatible

### DIFF
--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -31,7 +31,7 @@ function install_dependencies() {
     fi
 }
 
-cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+(cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull) || true
 if [[ -n "$BAZEL_BUILDBUDDY_CERT" && -n "$BAZEL_BUILDBUDDY_KEY" ]]; then
     echo "Installing BuildBuddy credential..."
     BAZEL_BUILDBUDDY_CREDENTIAL=/opt/.credentials/


### PR DESCRIPTION
Makes rbe.sh compatible with both CircleCI and Grabl