### PR TITLE
Update rules_nodejs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,8 @@
 
 workspace(name = "graknlabs_dependencies")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 ################################
 # Load @graknlabs_dependencies #
 ################################
@@ -62,6 +64,7 @@ node_repositories()
 # Load Python
 load("//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
+
 load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 pip3_import(
@@ -107,30 +110,25 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 # Load Docker
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/graknlabs/skydoc.git",
-    branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-)
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
+# load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+# git_repository(
+#     name = "io_bazel_skydoc",
+#     remote = "https://github.com/graknlabs/skydoc.git",
+#     branch = "experimental-skydoc-allow-dep-on-bazel-tools",
+# )
+# load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
+# skydoc_repositories()
+# load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+# rules_sass_dependencies()
+# load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+# sass_repositories()
 
 # Load Github
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
 tcnksm_ghr()
 
 # Load Python
-git_repository(
-    name = "io_bazel_rules_python",
-    remote = "https://github.com/bazelbuild/rules_python.git",
-    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
-)
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip_import")
 pip_repositories()
 pip_import(
     name = "graknlabs_bazel_distribution_pip",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -109,20 +109,6 @@ bazelbuild_rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
-# Load Docker
-# load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-# git_repository(
-#     name = "io_bazel_skydoc",
-#     remote = "https://github.com/graknlabs/skydoc.git",
-#     branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-# )
-# load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-# skydoc_repositories()
-# load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-# rules_sass_dependencies()
-# load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-# sass_repositories()
-
 # Load Github
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
 tcnksm_ghr()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,9 +56,8 @@ kt_register_toolchains()
 # Load NodeJS
 load("//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 node_repositories()
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
 
 # Load Python
 load("//builder/python:deps.bzl", python_deps = "deps")
@@ -124,10 +123,6 @@ sass_repositories()
 # Load Github
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
 tcnksm_ghr()
-
-# Load NodeJS
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
 
 # Load Python
 git_repository(

--- a/builder/nodejs/deps.bzl
+++ b/builder/nodejs/deps.bzl
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps():
     http_archive(
         name = "build_bazel_rules_nodejs",
-        sha256 = "3b0116a8a91a75678a57ba676c246ac0fa9c90dc3d46daef305b11b54ed4467e",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.33.1/rules_nodejs-0.33.1.tar.gz"],
+        sha256 = "10fffa29f687aa4d8eb6dfe8731ab5beb63811ab00981fc84a93899641fd4af1",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.3/rules_nodejs-2.0.3.tar.gz"],
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "6836a6ab4039c4d9126eb8ddbe4a8bf227ccc467" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "ea232e3963aca751a2e7813cee869be92356b0f0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "6836a6ab4039c4d9126eb8ddbe4a8bf227ccc467" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "ea232e3963aca751a2e7813cee869be92356b0f0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "732c5b0359e32543e266e7a7c74f73515c03d9f7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )

--- a/distribution/apt/BUILD
+++ b/distribution/apt/BUILD
@@ -1,5 +1,4 @@
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
-load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz")
 
 assemble_apt(
     name = "assemble-linux-apt",


### PR DESCRIPTION
We would like to update `rules_nodejs`, which required some complex fixes and updates in `bazel-distribution`. This PR implements some necessary changes for `rules_nodejs` migration to 2.x.x, and some other upgrades necessary for `bazel-distribution`.