### PR TITLE
Restrict the input for the tagged_deps field of release_validate_deps

### DIFF
--- a/tool/release/BUILD
+++ b/tool/release/BUILD
@@ -17,7 +17,7 @@
 
 
 load("@graknlabs_dependencies_ci_pip//:requirements.bzl", "requirement")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 exports_files(["ValidateDeps.kt"])
 
@@ -45,5 +45,13 @@ py_binary(
         requirement("idna"),
         requirement("wrapt"),
         requirement("certifi"),
+    ]
+)
+
+kt_jvm_library(
+    name = "x",
+    srcs = ["ValidateDeps.kt"],
+    deps = [
+        "@maven//:com_eclipsesource_minimal_json_minimal_json"
     ]
 )

--- a/tool/release/BUILD
+++ b/tool/release/BUILD
@@ -17,7 +17,6 @@
 
 
 load("@graknlabs_dependencies_ci_pip//:requirements.bzl", "requirement")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 exports_files(["ValidateDeps.kt"])
 
@@ -45,13 +44,5 @@ py_binary(
         requirement("idna"),
         requirement("wrapt"),
         requirement("certifi"),
-    ]
-)
-
-kt_jvm_library(
-    name = "x",
-    srcs = ["ValidateDeps.kt"],
-    deps = [
-        "@maven//:com_eclipsesource_minimal_json_minimal_json"
     ]
 )

--- a/tool/release/ValidateDeps.kt
+++ b/tool/release/ValidateDeps.kt
@@ -12,7 +12,7 @@ fun main() {
     val malformedDepsSet = taggedDepsSet.filter { dep -> !dep.startsWith("@") }
     if (malformedDepsSet.isNotEmpty()) {
         System.err.println("\nThe following dependencies do not start with an '@': $malformedDepsSet")
-        System.err.println("They must be declared with an '@', eg., ${malformedDepsSet.map { dep -> "@" + dep }}'")
+        System.err.println("Please prefix them with '@', ie., ${malformedDepsSet.map { dep -> "@" + dep }}'")
         System.exit(1)
     }
 

--- a/tool/release/ValidateDeps.kt
+++ b/tool/release/ValidateDeps.kt
@@ -12,7 +12,7 @@ fun main() {
     val malformedDepsSet = taggedDepsSet.filter { dep -> !dep.startsWith("@") }
     if (malformedDepsSet.isNotEmpty()) {
         System.err.println("\nThe following dependencies do not start with an '@': $malformedDepsSet")
-        System.err.println("They must be declared with an '@', eg., '@graknlabs_common'")
+        System.err.println("They must be declared with an '@', eg., ${malformedDepsSet.map { dep -> "@" + dep }}'")
         System.exit(1)
     }
 

--- a/tool/release/ValidateDeps.kt
+++ b/tool/release/ValidateDeps.kt
@@ -8,14 +8,22 @@ fun main() {
     val workspaceRefsPath = "{workspace_refs_json_path}"
     val taggedDeps = "{tagged_deps}"
 
+    val taggedDepsSet = taggedDeps.split(",").toSet()
+    val malformedDepsSet = taggedDepsSet.filter { dep -> !dep.startsWith("@") }
+    if (malformedDepsSet.isNotEmpty()) {
+        System.err.println("\nThe following dependencies do not start with an '@': $malformedDepsSet")
+        System.err.println("They must be declared with an '@', eg., '@graknlabs_common'")
+        System.exit(1)
+    }
+
     val refs = Paths.get(workspaceRefsPath)
     val refFileReader = FileReader(refs.toFile())
     val parsed = Json.parse(refFileReader).asObject()
 
-    val taggedDepsSet = taggedDeps.split(",").toSet().map { w -> w.replace("@", "") }
-
-    val tagDepsFromRefs = parsed["tags"].asObject().names().toSet()
-    val snapshotDependencies = taggedDepsSet.subtract(tagDepsFromRefs)
+    val taggedDepsFromRefs = parsed["tags"].asObject().names().toSet()
+    val snapshotDependencies = taggedDepsSet
+            .map { w -> w.replace("@", "") }
+            .subtract(taggedDepsFromRefs)
 
     if (snapshotDependencies.size > 0) {
         System.err.println("\nThese dependencies are expected to be declared by tag instead of commit: $snapshotDependencies")


### PR DESCRIPTION
The tagged_deps field has been made to strictly accept input in the following format: `@graknlabs_common`, and not `graknlabs_common`