### PR TITLE
Make checkstyle_test work with any file type

### DIFF
--- a/tool/checkstyle/config/checkstyle-file-header-agpl.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-agpl.txt
@@ -1,15 +1,15 @@
-^\W*
-^\W*Copyright \(C\) 2020 Grakn Labs$
-^\W*$
-^\W*This program is free software: you can redistribute it and/or modify$
-^\W*it under the terms of the GNU Affero General Public License as$
-^\W*published by the Free Software Foundation, either version 3 of the$
-^\W*License, or \(at your option\) any later version.$
-^\W*$
-^\W*This program is distributed in the hope that it will be useful,$
-^\W*but WITHOUT ANY WARRANTY; without even the implied warranty of$
-^\W*MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the$
-^\W*GNU Affero General Public License for more details.$
-^\W*$
-^\W*You should have received a copy of the GNU Affero General Public License$
-^\W*along with this program.  If not, see <https://www.gnu.org/licenses/>.$
+^.*
+^.*Copyright \(C\) 2020 Grakn Labs$
+^.*$
+^.*This program is free software: you can redistribute it and/or modify$
+^.*it under the terms of the GNU Affero General Public License as$
+^.*published by the Free Software Foundation, either version 3 of the$
+^.*License, or \(at your option\) any later version.$
+^.*$
+^.*This program is distributed in the hope that it will be useful,$
+^.*but WITHOUT ANY WARRANTY; without even the implied warranty of$
+^.*MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the$
+^.*GNU Affero General Public License for more details.$
+^.*$
+^.*You should have received a copy of the GNU Affero General Public License$
+^.*along with this program.  If not, see <https://www.gnu.org/licenses/>.$

--- a/tool/checkstyle/config/checkstyle-file-header-apache.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-apache.txt
@@ -1,17 +1,17 @@
-^\W*
-^\W*Licensed to the Apache Software Foundation \(ASF\) under one$
-^\W*or more contributor license agreements.  See the NOTICE file$
-^\W*distributed with this work for additional information$
-^\W*regarding copyright ownership.  The ASF licenses this file$
-^\W*to you under the Apache License, Version 2.0 \(the$
-^\W*"License"\); you may not use this file except in compliance$
-^\W*with the License.  You may obtain a copy of the License at$
-^\W*$
-^\W*http://www.apache.org/licenses/LICENSE-2.0$
-^\W*$
-^\W*Unless required by applicable law or agreed to in writing,$
-^\W*software distributed under the License is distributed on an$
-^\W*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY$
-^\W*KIND, either express or implied.  See the License for the$
-^\W*specific language governing permissions and limitations$
-^\W*under the License.$
+^.*
+^.*Licensed to the Apache Software Foundation \(ASF\) under one$
+^.*or more contributor license agreements.  See the NOTICE file$
+^.*distributed with this work for additional information$
+^.*regarding copyright ownership.  The ASF licenses this file$
+^.*to you under the Apache License, Version 2.0 \(the$
+^.*"License"\); you may not use this file except in compliance$
+^.*with the License.  You may obtain a copy of the License at$
+^.*$
+^.*http://www.apache.org/licenses/LICENSE-2.0$
+^.*$
+^.*Unless required by applicable law or agreed to in writing,$
+^.*software distributed under the License is distributed on an$
+^.*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY$
+^.*KIND, either express or implied.  See the License for the$
+^.*specific language governing permissions and limitations$
+^.*under the License.$

--- a/tool/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
@@ -1,10 +1,10 @@
-^\W*
-^\W*Copyright \(C\) 2020 Grakn Labs$
-^\W*$
-^\W*This unpublished material is proprietary to Grakn Labs.$
-^\W*All rights reserved. The methods and$
-^\W*techniques described herein are considered trade secrets$
-^\W*and/or confidential. Reproduction or distribution, in whole$
-^\W*or in part, is forbidden except by express written permission$
-^\W*of Grakn Labs.$
-^\W*$
+^\.*
+^\.*Copyright \(C\) 2020 Grakn Labs$
+^\.*$
+^\.*This unpublished material is proprietary to Grakn Labs.$
+^\.*All rights reserved. The methods and$
+^\.*techniques described herein are considered trade secrets$
+^\.*and/or confidential. Reproduction or distribution, in whole$
+^\.*or in part, is forbidden except by express written permission$
+^\.*of Grakn Labs.$
+^\.*$

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -54,7 +54,8 @@ def _checkstyle_test_impl(ctx):
 
     files = []
     for target in ctx.attr.include:
-        files.extend(target.files.to_list())
+        if target not in ctx.attr.exclude:
+            files.extend(target.files.to_list())
 
     cmd = " ".join(
         ["java -cp %s com.puppycrawl.tools.checkstyle.Main" % classpath] +
@@ -111,6 +112,7 @@ checkstyle_test = rule(
         "exclude": attr.label_list(
             doc = "A list of files that should be excluded from checking (in addition to the default exclusions)",
             allow_files = True,
+            default = [],
         ),
         "allow_failure": attr.bool(
             default = False,

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -15,30 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-SourceFiles = provider(
-    fields = {
-        'files' : 'source files'
-    }
-)
-
-
-def collect_sources_impl(target, ctx):
-    sources = []
-    if hasattr(ctx.rule.attr, 'srcs'):
-        for src in ctx.rule.attr.srcs:
-            for f in src.files.to_list():
-                sources.append(f)
-    return [SourceFiles(files = sources)]
-
-
-collect_sources = aspect(
-    implementation = collect_sources_impl,
-)
-
-
 def _checkstyle_test_impl(ctx):
-    if ctx.attr.target and "{}-checkstyle".format(ctx.attr.target.label.name) != ctx.attr.name:
-        fail("target should follow `{target name}-checkstyle` pattern")
     properties = ctx.file.properties
     opts = ctx.attr.opts
     sopts = ctx.attr.string_opts
@@ -76,10 +53,7 @@ def _checkstyle_test_impl(ctx):
       inputs.append(properties)
 
     files = []
-    for target in ctx.attr.targets + [ctx.attr.target]:
-        if target:
-            files.extend(target[SourceFiles].files)
-    for target in ctx.attr.files:
+    for target in ctx.attr.include:
         files.extend(target.files.to_list())
 
     cmd = " ".join(
@@ -130,16 +104,12 @@ checkstyle_test = rule(
         "string_opts": attr.string_dict(
             doc = "Options to be passed on the command line that have an argument"
         ),
-        "target": attr.label(
-            doc = "The target to check sources on",
-            aspects = [collect_sources],
+        "include": attr.label_list(
+            doc = "A list of files that should be checked",
+            allow_files = True,
         ),
-        "targets": attr.label_list(
-            doc = "A list of targets to check sources on",
-            aspects = [collect_sources],
-        ),
-        "files": attr.label_list(
-            doc = "A list of files to check",
+        "exclude": attr.label_list(
+            doc = "A list of files that should be excluded from checking (in addition to the default exclusions)",
             allow_files = True,
         ),
         "allow_failure": attr.bool(

--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -54,7 +54,8 @@ def _checkstyle_test_impl(ctx):
 
     files = []
     for target in ctx.attr.include:
-        if target not in ctx.attr.exclude:
+        path = target.files.to_list()[0].path;
+        if target not in ctx.attr.exclude and path not in ['.bazelversion', 'VERSION', 'RELEASE_TEMPLATE.md']:
             files.extend(target.files.to_list())
 
     cmd = " ".join(

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 
     workspace_files, _ = tc.shell_execute([
          'find', '.',
-         '(', '-name', '.git', '-o', '-name', '.ijwb', '-o', '-name', '.github', '-name', 'RELEASE_TEMPLATE.md', '-o', '-name', 'VERSION', '-o', '-name', '.bazelversion', ')', '-prune', '-o', # files to always exclude
+         '(', '-name', '.git', '-o', '-name', '.ijwb', '-o', '-name', '.github', '-o', '-name', 'RELEASE_TEMPLATE.md', '-o', '-name', 'VERSION', '-o', '-name', '.bazelversion', ')', '-prune', '-o', # files to always exclude
          '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     workspace_files = workspace_files.split()

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -46,11 +46,11 @@ if __name__ == '__main__':
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
     included_checkstyle_files = checkstyle_targets_tree.findall(".//list[@name='include']//label[@value]")
-    # TODO: support exclusions
+    excluded_checkstyle_files = checkstyle_targets_tree.findall(".//list[@name='exclude']//label[@value]")
     # examples:
     # - '//test/behaviour:BUILD' transforms to './test/behaviour/BUILD'
     # - '//:README.md' transforms to './README.md'
-    checkstyle_files = list(map(lambda x: x.get('value').replace('//:', './').replace('//', './').replace(':', '/'), included_checkstyle_files))
+    checkstyle_files = list(map(lambda x: x.get('value').replace('//:', './').replace('//', './').replace(':', '/'), included_checkstyle_files + excluded_checkstyle_files))
     unique_checkstyle_files = set(checkstyle_files)
 
     if len(unique_checkstyle_files) != len(checkstyle_files):
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     file_count = len(workspace_files_with_no_checkstyle)
 
     if workspace_files_with_no_checkstyle:
-        print('ERROR: Found %d workspace files which are not covered by a `checkstyle_test`:' % file_count)
+        print('ERROR: Found %d workspace files which are not covered by a `checkstyle_test`. They must be placed in either `include` or `exclude` in a `checkstyle_test`.' % file_count)
         for i, file_label in enumerate(workspace_files_with_no_checkstyle, start=1):
             print('%d: %s' % (i, file_label))
         sys.exit(1)

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -51,12 +51,21 @@ if __name__ == '__main__':
     # - '//test/behaviour:BUILD' transforms to './test/behaviour/BUILD'
     # - '//:README.md' transforms to './README.md'
     checkstyle_files = list(map(lambda x: x.get('value').replace('//:', './').replace('//', './').replace(':', '/'), included_checkstyle_files + excluded_checkstyle_files))
-    unique_checkstyle_files = set(checkstyle_files)
+    unique_included_checkstyle_files = set(included_checkstyle_files)
+    unique_excluded_checkstyle_files = set(excluded_checkstyle_files)
 
-    if len(unique_checkstyle_files) != len(checkstyle_files):
-        non_unique_checkstyle_file = set([x for x in checkstyle_files if checkstyle_files.count(x) > 1])
+    if len(unique_included_checkstyle_files) != len(included_checkstyle_files):
+        non_unique_checkstyle_file = set([x for x in included_checkstyle_files if included_checkstyle_files.count(x) > 1])
         non_unique_checkstyle_file_count = len(non_unique_checkstyle_file)
-        print('ERROR: Found %d workspace files which are covered more than once:' % non_unique_checkstyle_file_count)
+        print('ERROR: Found %d workspace files which are included more than once:' % non_unique_checkstyle_file_count)
+        for i, target_label in enumerate(non_unique_checkstyle_file, start=1):
+            print('%d: %s' % (i, target_label))
+        sys.exit(1)
+
+    if len(unique_excluded_checkstyle_files) != len(excluded_checkstyle_files):
+        non_unique_checkstyle_file = set([x for x in excluded_checkstyle_files if excluded_checkstyle_files.count(x) > 1])
+        non_unique_checkstyle_file_count = len(non_unique_checkstyle_file)
+        print('ERROR: Found %d workspace files which are excluded more than once:' % non_unique_checkstyle_file_count)
         for i, target_label in enumerate(non_unique_checkstyle_file, start=1):
             print('%d: %s' % (i, target_label))
         sys.exit(1)

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -35,8 +35,7 @@ if __name__ == '__main__':
 
     workspace_files, _ = tc.shell_execute([
          'find', '.',
-         '-type', 'd', '(', '-name', '.git', '-o', '-name', '.ijwb', '-o', '-name', '.github', ')', '-prune', '-o', # directories to always exclude
-         '-type', 'f', '(', '-name', 'RELEASE_TEMPLATE.md', '-o', '-name', 'VERSION', '-o', '-name', '.bazelversion', ')', '-prune', '-o', # files to always exclude
+         '(', '-name', '.git', '-o', '-name', '.ijwb', '-o', '-name', '.github', '-name', 'RELEASE_TEMPLATE.md', '-o', '-name', 'VERSION', '-o', '-name', '.bazelversion', ')', '-prune', '-o', # files to always exclude
          '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     workspace_files = workspace_files.split()

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -31,66 +31,43 @@ def try_decode(s):
 
 
 if __name__ == '__main__':
-    print('Checking if there are any source files not covered by checkstyle...')
+    print('Checking if there are any workspace files not covered by checkstyle...')
 
-    java_targets, _ = tc.shell_execute([
-        'bazel', 'query',
-        '(kind(java_library, //...) union kind(java_test, //...)) '
-        'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
+    workspace_files, _ = tc.shell_execute([
+         'find', '.',
+         '-type', 'd', '(', '-name', '.git', '-o', '-name', '.ijwb', '-o', '-name', '.github', ')', '-prune', '-o', # directories to always exclude
+         '-type', 'f', '(', '-name', 'RELEASE_TEMPLATE.md', '-o', '-name', 'VERSION', '-o', '-name', '.bazelversion', ')', '-prune', '-o', # files to always exclude
+         '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-    java_targets = java_targets.split()
-
-    # Get all BUILD and *.bzl files that are declared in the current repository
-    build_files, _ = tc.shell_execute([
-        'bazel', 'query', 'filter("^//.*", buildfiles(//...))'
-    ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-    build_files = build_files.split()
+    workspace_files = workspace_files.split()
 
     checkstyle_targets_xml, _ = tc.shell_execute([
         'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
-    java_targets_covered_by_target_attr = checkstyle_targets_tree.findall(".//label[@name='target'][@value]")
-    java_targets_covered_by_targets_attr = checkstyle_targets_tree.findall(".//list[@name='targets']//label[@value]")
-    checkstyle_targets = list(map(
-        lambda x: x.get('value'), java_targets_covered_by_target_attr + java_targets_covered_by_targets_attr))
-    unique_checkstyle_targets = set(checkstyle_targets)
-    files = checkstyle_targets_tree.findall(".//list[@name='files']//label[@value]")
-    checkstyle_files = list(map(lambda x: x.get('value'), files))
+    included_checkstyle_files = checkstyle_targets_tree.findall(".//list[@name='include']//label[@value]")
+    # TODO: support exclusions
+    # examples:
+    # - '//test/behaviour:BUILD' transforms to './test/behaviour/BUILD'
+    # - '//:README.md' transforms to './README.md'
+    checkstyle_files = list(map(lambda x: x.get('value').replace('//:', './').replace('//', './').replace(':', '/'), included_checkstyle_files))
     unique_checkstyle_files = set(checkstyle_files)
-
-    if len(unique_checkstyle_targets) != len(checkstyle_targets):
-        non_unique_checkstyle_target = set([x for x in checkstyle_targets if checkstyle_targets.count(x) > 1])
-        non_unique_checkstyle_target_count = len(non_unique_checkstyle_target)
-        print('ERROR: Found %d bazel targets which are covered more than once:' % non_unique_checkstyle_target_count)
-        for i, target_label in enumerate(non_unique_checkstyle_target, start=1):
-            print('%d: %s' % (i, target_label))
-        sys.exit(1)
 
     if len(unique_checkstyle_files) != len(checkstyle_files):
         non_unique_checkstyle_file = set([x for x in checkstyle_files if checkstyle_files.count(x) > 1])
         non_unique_checkstyle_file_count = len(non_unique_checkstyle_file)
-        print('ERROR: Found %d build files which are covered more than once:' % non_unique_checkstyle_file_count)
+        print('ERROR: Found %d workspace files which are covered more than once:' % non_unique_checkstyle_file_count)
         for i, target_label in enumerate(non_unique_checkstyle_file, start=1):
             print('%d: %s' % (i, target_label))
         sys.exit(1)
 
-    java_targets_with_no_checkstyle = set(java_targets) - set(checkstyle_targets)
-    target_count = len(java_targets_with_no_checkstyle)
+    workspace_files_with_no_checkstyle = set(workspace_files) - set(checkstyle_files)
+    file_count = len(workspace_files_with_no_checkstyle)
 
-    if java_targets_with_no_checkstyle:
-        print('ERROR: Found %d bazel targets which are not covered by a `checkstyle_test`:' % target_count)
-        for i, target_label in enumerate(java_targets_with_no_checkstyle, start=1):
-            print('%d: %s' % (i, target_label))
-        sys.exit(1)
-
-    build_files_with_no_checkstyle = set(build_files) - set(checkstyle_files)
-    file_count = len(build_files_with_no_checkstyle)
-
-    if build_files_with_no_checkstyle:
-        print('ERROR: Found %d build files which are not covered by a `checkstyle_test`:' % file_count)
-        for i, file_label in enumerate(build_files_with_no_checkstyle, start=1):
+    if workspace_files_with_no_checkstyle:
+        print('ERROR: Found %d workspace files which are not covered by a `checkstyle_test`:' % file_count)
+        for i, file_label in enumerate(workspace_files_with_no_checkstyle, start=1):
             print('%d: %s' % (i, file_label))
         sys.exit(1)
 
-    print('SUCCESS: Every Java source and build file is covered by a `checkstyle_test`!')
+    print('SUCCESS: Every workspace file is covered by a `checkstyle_test`!')


### PR DESCRIPTION
## What is the goal of this PR?

To make checkstyle_test work with any file type

## What are the changes implemented in this PR?

Deleted `targets` and `files`. Added `include` and `exclude`. They both take in a list of files (e.g. via a `glob`).

If a file is present in `include` it will be checked by checkstyle, unless it is also present in `exclude`. If a file is present in `exclude`, it will not be checked by checkstyle. If a file is present in neither `include` nor `exclude`, an error will be thrown by `checkstyle:test-coverage`.