### PR TITLE
Exclude all MD files from checkstyle

### DIFF
--- a/tool/checkstyle/rules.bzl
+++ b/tool/checkstyle/rules.bzl
@@ -55,7 +55,7 @@ def _checkstyle_test_impl(ctx):
     files = []
     for target in ctx.attr.include:
         path = target.files.to_list()[0].path;
-        if target not in ctx.attr.exclude and path not in ['.DS_Store', '.bazelversion', '.gitkeep', 'LICENSE', 'RELEASE_TEMPLATE.md', 'VERSION']:
+        if target not in ctx.attr.exclude and path not in ['.DS_Store', '.bazelversion', '.gitkeep', 'LICENSE', 'VERSION'] and not path.endswith('.md'):
             files.extend(target.files.to_list())
 
     cmd = " ".join(

--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -40,8 +40,8 @@ if __name__ == '__main__':
             '-o', '-name', '.github',
             '-o', '-name', '.bazelversion',
             '-o', '-name', '.gitkeep',
-            '-o', '-name', 'RELEASE_TEMPLATE.md',
             '-o', '-name', 'VERSION',
+            '-o', '-name', '*.md',
         ')', '-prune', '-o', '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     workspace_files = workspace_files.split()


### PR DESCRIPTION
## What is the goal of this PR?

To not require license headers in MD files

## What are the changes implemented in this PR?

Exclude all MD files from checkstyle and test-coverage