### PR TITLE
Use grabl status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grakn Dependencies
 
-[![CircleCI](https://circleci.com/gh/graknlabs/dependencies/tree/master.svg?style=shield)](https://circleci.com/gh/graknlabs/dependencies/tree/master)
+[![Grabl](https://grabl.io/api/status/graknlabs/dependencies/badge.svg)](https://grabl.io/graknlabs/dependencies)
 
 Bazel dependency declarations for build tools reused across @graknlabs repositories.
 


### PR DESCRIPTION
## What is the goal of this PR?

Use grabl status badge instead of circle CI since circle CI project is already removed.

