### PR TITLE
Make maven_install fetch source JARs as well

### DIFF
--- a/library/maven/rules.bzl
+++ b/library/maven/rules.bzl
@@ -20,7 +20,8 @@ def maven(artifacts_org, artifacts_repo={}):
             "https://repo.grakn.ai/repository/maven-snapshot",
         ],
         strict_visibility = True,
-        version_conflict_policy = "pinned"
+        version_conflict_policy = "pinned",
+        fetch_sources = True
     )
 
 def maven_artifact(artifact, artifact_info):


### PR DESCRIPTION
## What is the goal of this PR?

Previously, source JARs won't be fetched by `rules_jvm_internal` which made it impossible to _Go to source_ in IntelliJ.

## What are the changes implemented in this PR?

Configure `rules_jvm_internal` to fetch source JARs as well
