### PR TITLE
Allow hashbangs at the start of Checkstyle targets

### DIFF
--- a/tool/checkstyle/config/checkstyle-file-header-agpl.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-agpl.txt
@@ -1,3 +1,4 @@
+^#!.*
 ^.*
 ^.*Copyright \(C\) 2020 Grakn Labs$
 ^.*$

--- a/tool/checkstyle/config/checkstyle-file-header-apache.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-apache.txt
@@ -1,3 +1,4 @@
+^#!.*
 ^.*
 ^.*Licensed to the Apache Software Foundation \(ASF\) under one$
 ^.*or more contributor license agreements.  See the NOTICE file$

--- a/tool/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
+++ b/tool/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
@@ -1,3 +1,4 @@
+^#!.*
 ^\.*
 ^\.*Copyright \(C\) 2020 Grakn Labs$
 ^\.*$

--- a/tool/checkstyle/templates/checkstyle.xml
+++ b/tool/checkstyle/templates/checkstyle.xml
@@ -34,6 +34,7 @@
     <module name="RegexpHeader">
         <property name="id" value="licenseHeader"/>
         <property name="headerFile" value="{licenseFile}"/>
+        <property name="multiLines" value="1"/>
     </module>
 
     <module name="TreeWalker">


### PR DESCRIPTION
## What is the goal of this PR?

To allow Bash scripts to pass checkstyle tests (i.e. shell scripts that are instructed to execute in Bash)

## What are the changes implemented in this PR?

Each of our license templates now has `^#!.*` as line 1, while `checkstyle.xml` defines line 1 as a `multiLine`, meaning it is allowed to match zero or more times.

As a result, hashbangs are now allowed at the start of Checkstyle targets.

Example shell script (passing the new checkstyle test):
```
#!/usr/bin/env bash
#
# Copyright (C) 2020 Grakn Labs
#
# This program is free software: you can redistribute it and/or modify ...
```