### PR TITLE
Allow short SHAs in snapshot artifacts

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
-        remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "0bfdf4cf68ae1948b05fc34e12698334091a54d0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        remote = "https://github.com/alexjpwalker/bazel-distribution",
+        commit = "ea5f014e3c6d51c1c964abc93d40f8590e696256" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )


### PR DESCRIPTION
## What is the goal of this PR?

To allow Grakn to run in Linux.

See https://github.com/graknlabs/bazel-distribution/pull/265.

## What are the changes implemented in this PR?

Update bazel-distribution
