### PR TITLE
Remove hard-coded Java path

### DIFF
--- a/library/rocksdbjni/BUILD
+++ b/library/rocksdbjni/BUILD
@@ -26,7 +26,6 @@ kt_jvm_binary(
     main_class = "library.rocksdbjni.RocksDbBuilderKt",
     srcs = ["RocksDbBuilder.kt"],
     deps = [
-        # Maven dependencies
         "@maven//:org_zeroturnaround_zt_exec"
     ],
 )

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -39,7 +39,8 @@ fun shellScript(script: String, baseDir: Path, javaHome: Path?): ProcessResult? 
     println(script)
     var builder = ProcessExecutor(script.split(" "))
             .readOutput(true)
-            .redirectOutput(System.out).redirectError(System.err)
+            .redirectOutput(System.out)
+            .redirectError(System.err)
             .directory(baseDir.toFile())
     if (javaHome != null) {
         builder = builder.environment("JAVA_HOME", javaHome.toAbsolutePath().toString())

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -8,9 +8,7 @@ import java.nio.file.Paths
 fun main() {
     val baseDir = Paths.get(".")
     val version = Paths.get("library").resolve("rocksdbjni").resolve("VERSION").toFile().useLines { it.firstOrNull() }
-    val javaHome = Paths.get(
-            shellScript("/usr/libexec/java_home", baseDir, null)!!.outputUTF8().trim()
-    )
+    val javaHome = Paths.get(shellScript("/usr/libexec/java_home", baseDir, null)!!.outputUTF8().trim())
 
     shellScript("git clone git@github.com:facebook/rocksdb.git", baseDir, javaHome)
 

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -4,7 +4,6 @@ import org.zeroturnaround.exec.ProcessExecutor
 import org.zeroturnaround.exec.ProcessResult
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.test.assertNotNull
 
 fun main() {
     val baseDir = Paths.get(".")

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -8,7 +8,8 @@ import java.nio.file.Paths
 fun main() {
     val baseDir = Paths.get(".")
     val version = Paths.get("library").resolve("rocksdbjni").resolve("VERSION").toFile().useLines { it.firstOrNull() }
-    val javaHome = "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home"
+
+    val javaHome = shellScript("/usr/libexec/java_home", Paths.get(".").toFile(), ".")!!.outputUTF8().trim()
 
     shellScript("git clone git@github.com:facebook/rocksdb.git", baseDir.toFile(), javaHome)
 
@@ -38,6 +39,7 @@ fun main() {
 fun shellScript(cmd: String, baseDir: File, javaHome: String): ProcessResult? {
     println(cmd)
     return ProcessExecutor(cmd.split(" "))
+            .readOutput(true)
             .redirectOutput(System.out).redirectError(System.err)
             .environment("JAVA_HOME", javaHome)
             .directory(baseDir).execute()

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -4,11 +4,13 @@ import org.zeroturnaround.exec.ProcessExecutor
 import org.zeroturnaround.exec.ProcessResult
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.test.assertNotNull
 
 fun main() {
     val baseDir = Paths.get(".")
     val version = Paths.get("library").resolve("rocksdbjni").resolve("VERSION").toFile().useLines { it.firstOrNull() }
-    val javaHome = Paths.get(shellScript("/usr/libexec/java_home", baseDir, null)!!.outputUTF8().trim())
+
+    val javaHome = Paths.get(shellScript("/usr/libexec/java_home", baseDir, null).outputUTF8().trim())
 
     shellScript("git clone git@github.com:facebook/rocksdb.git", baseDir, javaHome)
 
@@ -35,8 +37,8 @@ fun main() {
     sourcesJar.copyTo(sourcesDestPath)
 }
 
-fun shellScript(script: String, baseDir: Path, javaHome: Path?): ProcessResult? {
-    println(script)
+fun shellScript(script: String, baseDir: Path, javaHome: Path?): ProcessResult {
+    println("RocksDbBuilder.kt: '$script'")
     var builder = ProcessExecutor(script.split(" "))
             .readOutput(true)
             .redirectOutput(System.out)

--- a/library/rocksdbjni/RocksDbBuilder.kt
+++ b/library/rocksdbjni/RocksDbBuilder.kt
@@ -2,30 +2,30 @@ package library.rocksdbjni
 
 import org.zeroturnaround.exec.ProcessExecutor
 import org.zeroturnaround.exec.ProcessResult
-import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 
 fun main() {
     val baseDir = Paths.get(".")
     val version = Paths.get("library").resolve("rocksdbjni").resolve("VERSION").toFile().useLines { it.firstOrNull() }
     val javaHome = Paths.get(
-            shellScript("/usr/libexec/java_home", baseDir.toFile(), null)!!.outputUTF8().trim()
-    ).toFile()
+            shellScript("/usr/libexec/java_home", baseDir, null)!!.outputUTF8().trim()
+    )
 
-    shellScript("git clone git@github.com:facebook/rocksdb.git", baseDir.toFile(), javaHome)
+    shellScript("git clone git@github.com:facebook/rocksdb.git", baseDir, javaHome)
 
     val rocksDbDir = Paths.get("rocksdb")
-    shellScript("git checkout v$version", rocksDbDir.toFile(), javaHome)
+    shellScript("git checkout v$version", rocksDbDir, javaHome)
 
-    shellScript("brew install cmake", rocksDbDir.toFile(), javaHome)
+    shellScript("brew install cmake", rocksDbDir, javaHome)
 
-    shellScript("make clean jclean", rocksDbDir.toFile(), javaHome)
+    shellScript("make clean jclean", rocksDbDir, javaHome)
 
-    shellScript("make -j8 rocksdbjava", rocksDbDir.toFile(), javaHome)
+    shellScript("make -j8 rocksdbjava", rocksDbDir, javaHome)
 
     val srcMainJavaDir = Paths.get("rocksdb", "java", "src", "main", "java")
     val sourcesJarName = "rocksdbjni-$version-sources.jar"
-    shellScript("jar -cf ../../../target/$sourcesJarName org", srcMainJavaDir.toFile(), javaHome)
+    shellScript("jar -cf ../../../target/$sourcesJarName org", srcMainJavaDir, javaHome)
 
     val versionedJarName = "rocksdbjni-$version-osx.jar"
     val jar = rocksDbDir.resolve("java").resolve("target").resolve(versionedJarName).toFile()
@@ -37,14 +37,14 @@ fun main() {
     sourcesJar.copyTo(sourcesDestPath)
 }
 
-fun shellScript(cmd: String, baseDir: File, javaHome: File?): ProcessResult? {
-    println(cmd)
-    var builder = ProcessExecutor(cmd.split(" "))
+fun shellScript(script: String, baseDir: Path, javaHome: Path?): ProcessResult? {
+    println(script)
+    var builder = ProcessExecutor(script.split(" "))
             .readOutput(true)
             .redirectOutput(System.out).redirectError(System.err)
-            .directory(baseDir)
+            .directory(baseDir.toFile())
     if (javaHome != null) {
-        builder = builder.environment("JAVA_HOME", javaHome.toPath().toAbsolutePath().toString())
+        builder = builder.environment("JAVA_HOME", javaHome.toAbsolutePath().toString())
     }
     return builder.execute()
 }


### PR DESCRIPTION
## What is the goal of this PR?

We have removed the hard-coded `JAVA_HOME` in `RocksDbBuilder.kt`. It is now retrieved dynamically with `/usr/libexec/java_home`.

This is something that wasn't possible before and is only made possible by making Java available within the sandbox. Specifically, we're talking about adding Java toolchain in the `tools` attribute (which apparently was already added in the [original PR](https://github.com/graknlabs/dependencies/pull/203) for a seemingly different reason):

```
genrule(
    name = "builder",
    ...
    tools = ["@bazel_tools//tools/jdk:current_host_java_runtime", ":build-script"],
)
```