### PR TITLE
Add native_java_libraries and host_compatible_java_library

### DIFF
--- a/builder/java/rules.bzl
+++ b/builder/java/rules.bzl
@@ -1,0 +1,69 @@
+def native_java_libraries(name, deps = [], mac_deps = [], linux_deps = [], windows_deps = [], native_libraries_deps = [], **kwargs):
+    all_mac_deps = []
+    for dep in deps + mac_deps:
+        all_mac_deps.append(dep)
+    for dep in native_libraries_deps:
+        all_mac_deps.append(dep + "-mac")
+
+    native.java_library(
+        name = name + "-mac",
+        deps = all_mac_deps,
+        **kwargs,
+    )
+
+    all_linux_deps = []
+    for dep in deps + linux_deps:
+        all_linux_deps.append(dep)
+    for dep in native_libraries_deps:
+        all_linux_deps.append(dep + "-linux")
+
+    native.java_library(
+        name = name + "-linux",
+        deps = all_linux_deps,
+        **kwargs,
+    )
+
+    all_windows_deps = []
+    for dep in deps + windows_deps:
+        all_windows_deps.append(dep)
+    for dep in native_libraries_deps:
+        all_windows_deps.append(dep + "-windows")
+
+    native.java_library(
+        name = name + "-windows",
+        deps = all_windows_deps,
+        **kwargs,
+    )
+
+
+def host_compatible_java_library(name, deps = [], native_libraries_deps = [], **kwargs):
+    native_deps = []
+    for dep in native_libraries_deps:
+        native_deps = native_deps + native_dep_for_host_platform(dep)
+
+    native.java_library(
+        name = name,
+        deps = deps + native_deps,
+        **kwargs
+    )
+
+
+def host_compatible_java_test(name, deps = [], native_libraries_deps = [], **kwargs):
+    native_deps = []
+    for dep in native_libraries_deps:
+        native_deps = native_deps + native_dep_for_host_platform(dep)
+
+    native.java_test(
+       name = name,
+       deps = deps + native_deps,
+       **kwargs,
+   )
+
+
+def native_dep_for_host_platform(name):
+    return select({
+         "@graknlabs_dependencies//library/ortools:is_mac": [name + "-mac"],
+         "@graknlabs_dependencies//library/ortools:is_linux": [name + "-linux"],
+         "@graknlabs_dependencies//library/ortools:is_windows": [name + "-windows"],
+         "//conditions:default": [name + "-mac"],
+     })


### PR DESCRIPTION
## What is the goal of this PR?

To allow all five of the following operations to succeed in Grakn Core 2.0 since bringing in Google ORTools, which provides only native (platform-specific) JARs:

1. Building a Windows, Mac or Linux distribution on any machine, even if the target platform is different to the host platform
2. Compiling the project locally in IntelliJ using, say, `bazel build //...`
3. Running the tests locally
4. Compiling the project in Grabl
5. Running the tests in Grabl

## What are the changes implemented in this PR?

We add three new Bazel macros:

#### `native_java_libraries`
Replaces `java_library`. This macro expands to 3 platform-native `java_library` targets. For example:
```
native_java_libraries(
  name = "pattern",
  srcs = glob(["*.java"]),
  deps = ["//common:common"],
  native_libraries_deps = ["//traversal:traversal"]
)
```
expands to:
```
java_library(
  name = "pattern-mac",
  srcs = glob(["*.java"]),
  deps = ["//common:common", "//traversal:traversal-mac"]
)

java_library(
  name = "pattern-linux",
  srcs = glob(["*.java"]),
  deps = ["//common:common", "//traversal:traversal-linux"]
)

java_library(
  name = "pattern-windows",
  srcs = glob(["*.java"]),
  deps = ["//common:common", "//traversal:traversal-windows"]
)
```
It has 3 other properties too: `mac_deps`, `linux_deps` and `windows_deps`. These can be used to pull in external native JARs, such as Google ORTools. As the property names suggest, they only get expanded to the `java_library` for their respective platform.

`native_java_libraries` is intended for packages used by the Grakn runtime. At the top level, we use `native_java_libraries` to generate `server-mac`, `server-linux` and `server-windows`. These respectively end up in `assemble-mac-zip`, `assemble-linux-targz` and the (not yet created) `assemble-windows-zip`.

#### `host_compatible_java_library`
Also replaces `java_library`. This macro expands to just 1 `java_library` target which is native to the platform of the machine running Bazel. So when we're on our local machines, it'll expand to a Mac-compatible library; when Grabl builds it, it'll expand to a Linux-compatible library. For example, on our local machines:
```
host_compatible_java_library(
    name = "steps",
    srcs = ["AttributeTypeSteps.java"],
    deps = ["//common:common", "//test/behaviour/connection:steps"],
    native_libraries_deps = ["//concept:concept"]
)
```
expands to
```
java_library(
    name = "steps",
    srcs = ["AttributeTypeSteps.java"],
    deps = ["//common:common", "//test/behaviour/connection:steps", "//concept:concept-mac"],
)
```
`host_compatible_java_library` is intended for packages used only at build time. Currently, this means: our integration tests and behaviour tests.

#### `host_compatible_java_test`
Replaces `java_test`. In some cases, our `java_test` targets need to support `native_libraries_deps` too, and this macro enables that. It behaves identically to `host_compatible_java_library`.

The reason we don't need it for _all_ our tests is because, in our Behaviour tests, we have separate targets for the test steps - so it's the `:steps` that need to include native libraries, not the `java_test` targets. But in our Integration tests, we don't - so we need to include the native libraries directly from the `java_test` targets using `host_compatible_java_test`.