### PR TITLE
Make RBE script portable (to support CentOS)

### DIFF
--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -21,8 +21,11 @@ function install_dependencies() {
     echo "Installing rpmbuild..."
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
         apt_wait
-        sudo apt-get update
-        sudo apt-get install rpm
+        if ! command -v rpmbuild &> /dev/null
+        then
+            sudo apt-get update
+            sudo apt-get install rpm
+        fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         brew install rpm
     else


### PR DESCRIPTION
## What is the goal of this PR?

Currently, there is an assumption embedded into `tool/bazelinstall/rbe.sh`: if we're running on Linux, it must be Ubuntu. However, as we're integrating CentOS into our workflow, this assumption no longer holds true - it doesn't have `apt-get` and it already has `rpmbuild` (which, consequently, doesn't need to be installed there as it's already present)

## What are the changes implemented in this PR?

Only install `rpmbuild` if it's not present yet.
