### PR TITLE
Upgrade nodejs build rules

### DIFF
--- a/builder/nodejs/deps.bzl
+++ b/builder/nodejs/deps.bzl
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps():
     http_archive(
         name = "build_bazel_rules_nodejs",
-        sha256 = "10fffa29f687aa4d8eb6dfe8731ab5beb63811ab00981fc84a93899641fd4af1",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.3/rules_nodejs-2.0.3.tar.gz"],
+        sha256 = "f2194102720e662dbf193546585d705e645314319554c6ce7e47d8b59f459e9c",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Update bazel build rules nodejs for benefit of protocol compilation

## What are the changes implemented in this PR?

Upgrade to rules_nodejs 2.2.2 in builder/nodejs