### PR TITLE
Don't subject node_modules to checkstyle:test-coverage

### DIFF
--- a/tool/checkstyle/test-coverage.py
+++ b/tool/checkstyle/test-coverage.py
@@ -36,12 +36,14 @@ if __name__ == '__main__':
     workspace_files, _ = tc.shell_execute([
         'find', '.',
             '(', '-name', '.git',
+            '-o', '-name', '.idea',
             '-o', '-name', '.ijwb',
             '-o', '-name', '.github',
             '-o', '-name', '.bazelversion',
             '-o', '-name', '.gitkeep',
             '-o', '-name', 'VERSION',
             '-o', '-name', '*.md',
+            '-o', '-name', 'node_modules',
         ')', '-prune', '-o', '-type', 'f', '-print'
     ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     workspace_files = workspace_files.split()


### PR DESCRIPTION
## What is the goal of this PR?

To fix checkstyle:test-coverage failing in projects that use `npm`

## What are the changes implemented in this PR?

Exclude node_modules and .idea from checkstyle:test-coverage
