### PR TITLE
DependencyAnalysis: update dependency filename

### DIFF
--- a/grabl/analysis/DependencyAnalysis.kt
+++ b/grabl/analysis/DependencyAnalysis.kt
@@ -37,7 +37,7 @@ fun main() {
     val grablEndpoint = "/api/analysis/dependency-analysis"
     val workflow = System.getenv("GRABL_WORKFLOW")
             ?: throw RuntimeException("GRABL_WORKFLOW environment variable is not set")
-    val dependencies = Paths.get(workspaceDirectory, "dependencies", "graknlabs", "dependencies.bzl")
+    val dependencies = Paths.get(workspaceDirectory, "dependencies", "graknlabs", "repositories.bzl")
 
     var repositoriesArray = Json.array()
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently file where external repo dependencies are declared is named `repositories.bzl`; dependency analysis script still uses the old name to read them.

## What are the changes implemented in this PR?

Rename `dependencies.bzl` to `repositories.bzl`