### PR TITLE
Fix dependency-analyis false-negative results

### DIFF
--- a/grabl/analysis/DependencyAnalysis.kt
+++ b/grabl/analysis/DependencyAnalysis.kt
@@ -13,7 +13,7 @@ fun httpPost(url: String, json: JsonObject) {
     val expectedCode = "202"
     ProcessExecutor(
             "curl", "--silent",
-            "--output", "/dev/stderr",
+            "--output", "-",
             "--write-out", "%{http_code}",
             "-H", "Content-Type: application/json",
             "--data", json.toString(),


### PR DESCRIPTION
## What is the goal of this PR?

Currently, even successful executions of `dependency-analysis` fail the job. It happens because we tell `curl` to redirect output to the wrong stream (stderr instead of stdout).

## What are the changes implemented in this PR?

Make `curl` output exit code to `stdout` (which is later matched with "202")