### PR TITLE
Update how Maven dependencies are loaded

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ google_or_tools_linux()
 google_or_tools_windows()
 
 # Load //tool/common
-load("//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip")
+load("//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip", graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
 graknlabs_dependencies_ci_pip()
 load("@graknlabs_dependencies_ci_pip//:requirements.bzl",graknlabs_dependencies_ci_pip_install = "pip_install")
 graknlabs_dependencies_ci_pip_install()
@@ -75,4 +75,4 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 # Load Maven artifacts
-maven(["org.zeroturnaround:zt-exec", "com.eclipsesource.minimal-json:minimal-json"])
+maven(graknlabs_dependencies_tool_maven_artifacts)

--- a/tool/common/deps.bzl
+++ b/tool/common/deps.bzl
@@ -8,4 +8,5 @@ def graknlabs_dependencies_ci_pip():
 
 maven_artifacts = [
   "com.eclipsesource.minimal-json:minimal-json",
+  "org.zeroturnaround:zt-exec",
 ]


### PR DESCRIPTION
## What is the goal of this PR?

Ensure Maven artifacts are loaded from the same place where other repos could find them too: `//tool/common:deps.bzl`.

## What are the changes implemented in this PR?

* Update `maven_artifacts` in `tool/common/deps.bzl` to reflect actual Maven dependencies of `graknlabs_dependencies`
* Load Maven artifacts from `tool/common/deps.bzl` instead of specifying directly in `WORKSPACE`