### PR TITLE
Pull in graknlabs_grakn_core artifact for Windows

### DIFF
--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -1,7 +1,7 @@
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_file")
 
 def native_artifact_files(name, artifact_name, **kwargs):
-    for platform in ["mac", "linux"]:
+    for platform in ["mac", "linux", "windows"]:
         artifact_file(
             name = name + "_" + platform,
             # Can't use .format() because the result string will still have the unresolved parameter {version}


### PR DESCRIPTION
## What is the goal of this PR?

Currently, it's impossible to fetch Windows artifact with `native_artifact_files` macro

## What are the changes implemented in this PR?

Include `windows` as platform to pull artifacts for
