### PR TITLE
BuildBuddy Ubuntu 20.04 image to do builds on

### DIFF
--- a/image/buildbuddy/BUILD
+++ b/image/buildbuddy/BUILD
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "ubuntu-2004",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+    ],
+    exec_properties = {
+        "OSFamily": "Linux",
+        "container-image": "docker://gcr.io/grakn-dev/graknlabs-ubuntu-20.04@sha256:b2e6cbcff84d043ccc1bf06547a10e0a16c6463e352909a2cc02fb219a4ee01b",
+    },
+)
+

--- a/image/buildbuddy/Dockerfile
+++ b/image/buildbuddy/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+ENV TZ Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone && \
+    apt-get update && \
+    apt-get install -y build-essential openjdk-11-jdk rpm python2 python3 python-is-python2 unzip && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What is the goal of this PR?

Currently, there is a need to upgrade our builds to be done on recent Ubuntu (20.04) and Java 11. This requires a custom Java image.

## What are the changes implemented in this PR?

* Add `//image/buildbuddy` package to store `platform` in
* `Dockerfile` to build an image with all our build dependencies