### PR TITLE
Fix tool/bazelinstall/mac.sh

### DIFF
--- a/tool/bazelinstall/mac.sh
+++ b/tool/bazelinstall/mac.sh
@@ -3,7 +3,7 @@
 set -e
 BAZEL_VERSION=3.3.1
 
-brew cask install homebrew/cask-versions/adoptopenjdk8
+brew install --cask homebrew/cask-versions/adoptopenjdk8
 curl -OL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 chmod +x bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 sudo ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh


### PR DESCRIPTION
## What is the goal of this PR?

Currently, installing Bazel under Mac in CI (for example, in Core) fails with `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.` message.

## What are the changes implemented in this PR?

Apply the suggestion and install cask correctly