### PR TITLE
Implement validation of Python dependencies

### DIFF
--- a/tool/release/BUILD
+++ b/tool/release/BUILD
@@ -21,7 +21,7 @@ load("@graknlabs_dependencies_ci_pip//:requirements.bzl", "requirement")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
 
 
-exports_files(["ValidateDeps.kt", "ValidateNodeJsDeps.kt"])
+exports_files(["ValidateDeps.kt", "ValidateNodeJsDeps.kt", "ValidatePythonDeps.kt"])
 
 py_binary(
     name = "docs",

--- a/tool/release/ValidatePythonDeps.kt
+++ b/tool/release/ValidatePythonDeps.kt
@@ -1,0 +1,50 @@
+package tool.release
+
+import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonObject
+import com.google.api.client.http.GenericUrl
+import com.google.api.client.http.javanet.NetHttpTransport
+import java.io.FileReader
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.regex.Pattern
+
+
+fun httpGetJson(url: String?): JsonObject {
+    return Json.parse(NetHttpTransport()
+            .createRequestFactory()
+            .buildGetRequest(GenericUrl(url))
+            .execute()
+            .parseAsString()).asObject()
+}
+
+
+fun main(args: Array<String>) {
+    @Suppress("NAME_SHADOWING") val args = args.toMutableList()
+    val requirements = Files.readAllLines(Paths.get(args.removeAt(0))).filter {
+        !it.startsWith("#") && it.trim().isNotBlank()
+    }.associate {
+        val items = it.replace(">=", "==").split("==")
+        items[0] to items[1]
+    }
+
+    val versionRegex = Pattern.compile("^(\\d+!)?(\\d+)(\\.\\d+)+([\\.\\-\\_])?((a(lpha)?|b(eta)?|c|r(c|ev)?|pre(view)?)\\d*)?(\\.?(post|dev)\\d*)?\$")
+    val pypiAddress = "https://pypi.org/pypi/%s/json"
+
+    args.forEach {
+        val version = requirements.get(it)
+                ?: throw RuntimeException("dependency is not present in requirements.txt: $it")
+
+        if (!versionRegex.matcher(version).matches()) {
+            throw RuntimeException("invalid version of $it: $version")
+        }
+
+        val url = pypiAddress.format(it)
+        try {
+            httpGetJson(url).get("releases").asObject().get(version).asObject()
+        } catch (e: Exception) {
+            throw RuntimeException("cannot download version $version of $it (url $url); please ensure it has been released to pypi.org")
+        }
+    }
+
+}

--- a/tool/release/rules.bzl
+++ b/tool/release/rules.bzl
@@ -95,5 +95,29 @@ def release_validate_nodejs_deps(
                 "@maven//:com_eclipsesource_minimal_json_minimal_json",
                 "@maven//:com_google_http_client_google_http_client",
             ],
-            args = ["$(location {})".format(package_json)] + tagged_deps
+            args = ["$(location {})".format(package_json)] + tagged_deps,
+            tags = ["manual"],
+        )
+
+
+def release_validate_python_deps(
+        name,
+        requirements,
+        tagged_deps,
+    ):
+        kt_jvm_test(
+            name = name,
+            main_class = "tool.release.ValidatePythonDepsKt",
+            srcs = [
+                "@graknlabs_dependencies//tool/release:ValidatePythonDeps.kt"
+            ],
+            data = [
+                requirements,
+            ],
+            deps = [
+                "@maven//:com_eclipsesource_minimal_json_minimal_json",
+                "@maven//:com_google_http_client_google_http_client",
+            ],
+            args = ["$(location {})".format(requirements)] + tagged_deps,
+            tags = ["manual"],
         )


### PR DESCRIPTION
## What is the goal of this PR?

Currently, it's possible to release a Python package which still depends on a snapshot version (say, from `repo.grakn.ai`). In order to prevent it, we need to run a test which goes over `requirements.txt` and verifies that dependencies are properly versioned.

## What are the changes implemented in this PR?

Implement `release_validate_python_deps`; sample usage:

```
release_validate_python_deps(
    name = "release-validate-python-deps",
    requirements = "//:requirements.txt",
    tagged_deps = ["graknprotocol"]
)
```