### PR TITLE
Change web-dev to web-docs

### DIFF
--- a/tool/release/docs.py
+++ b/tool/release/docs.py
@@ -18,7 +18,7 @@ git_token = git_username + ":" + os.environ['RELEASE_DOCS_TOKEN']
 
 git_org = "graknlabs"
 
-git_repo = "web-dev"
+git_repo = "web-docs"
 git_branch = sys.argv[1]
 
 git_submod_repo = "docs"
@@ -26,7 +26,7 @@ git_submod_commit = sys.argv[2]
 
 git_remote = "github.com/{0}/{1}.git".format(git_org, git_repo)
 
-git_clone_dir = os.path.join("web-dev")
+git_clone_dir = os.path.join("web-docs")
 git_clone_submod_dir = os.path.join(git_clone_dir, "docs")
 
 
@@ -37,7 +37,7 @@ def short_commit(commit_sha):
 if __name__ == '__main__':
     try:
         print('Starting the process of deploying {0} to {1}:{2}'.format(git_submod_repo, git_repo, git_branch))
-        # --recursive clones web-dev as well as the docs submodule
+        # --recursive clones web-docs as well as the docs submodule
         print('Cloning {0} to {1}'.format(git_remote, git_clone_dir))
 
         sp.check_call(['rm', '-rf', git_clone_dir])


### PR DESCRIPTION
## What is the goal of this PR?

As we've renamed `web-dev` to `web-docs`, a release tool we use also needs to be updated.

## What are the changes implemented in this PR?

Update `web-dev` references to `web-docs`