### PR TITLE
Fix release_validate_python_deps

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -21,5 +21,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "b1047c9a324fa00892d47a4765ae27ab3972ab10" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "c204c87046674cd981554a8d9aa0758217a460fe" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )

--- a/tool/release/ValidatePythonDeps.kt
+++ b/tool/release/ValidatePythonDeps.kt
@@ -22,7 +22,7 @@ fun httpGetJson(url: String?): JsonObject {
 fun main(args: Array<String>) {
     @Suppress("NAME_SHADOWING") val args = args.toMutableList()
     val requirements = Files.readAllLines(Paths.get(args.removeAt(0))).filter {
-        !it.startsWith("#") && it.trim().isNotBlank()
+        !it.startsWith("#") && !it.startsWith("--") && it.trim().isNotBlank()
     }.associate {
         val items = it.replace(">=", "==").split("==")
         items[0] to items[1]


### PR DESCRIPTION
## What is the goal of this PR?

Similarly to graknlabs/bazel-distribution#281, we want to ignore `--extra-index-url` line in `requirements` file that we pass to `release_validate_python_deps`.

## What are the changes implemented in this PR?

Ignore lines beginning with `--` and bump `@graknlabs_bazel_distribution` to latest `master`