### PR TITLE
Fix Docker rules for Grakn Cluster

### DIFF
--- a/distribution/docker/BUILD
+++ b/distribution/docker/BUILD
@@ -1,0 +1,1 @@
+exports_files(["bazelbuild-rules-docker-fix-tarfile-format.patch"])

--- a/distribution/docker/bazelbuild-rules-docker-fix-tarfile-format.patch
+++ b/distribution/docker/bazelbuild-rules-docker-fix-tarfile-format.patch
@@ -1,0 +1,20 @@
+---
+ container/archive.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/container/archive.py b/container/archive.py
+index 0c875a3..d70696b 100644
+--- a/container/archive.py
++++ b/container/archive.py
+@@ -145,7 +145,7 @@ class TarFileWriter(object):
+       mode=mode,
+       fileobj=self.fileobj,
+       # https://github.com/bazelbuild/rules_docker/issues/1602
+-      format=tarfile.PAX_FORMAT)
++      format=tarfile.USTAR_FORMAT)
+     self.members = set([])
+     self.directories = set([])
+ 
+-- 
+2.27.0
+

--- a/distribution/docker/deps.bzl
+++ b/distribution/docker/deps.bzl
@@ -6,4 +6,8 @@ def deps():
         sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
         strip_prefix = "rules_docker-0.15.0",
         urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
+        patches = [
+            "@graknlabs_dependencies//distribution/docker:bazelbuild-rules-docker-fix-tarfile-format.patch",
+        ],
+        patch_args = ["-p1"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Patch `rules_docker` in order for us to be able to build Docker image for Grakn Cluster.

## What are the changes implemented in this PR?

Patch `rules_docker` such that an image can be built