### PR TITLE
Support self-hosted Bazel remote cache

### DIFF
--- a/tool/bazelinstall/rbe.sh
+++ b/tool/bazelinstall/rbe.sh
@@ -2,18 +2,15 @@
 
 set -e
 
-if [[ -n "$BAZEL_BUILDBUDDY_CERT" && -n "$BAZEL_BUILDBUDDY_KEY" ]]; then
-    echo "Installing BuildBuddy credential..."
-    BAZEL_BUILDBUDDY_CREDENTIAL=/opt/credentials/
-    echo "A BuildBuddy credential is found and will be saved to $BAZEL_BUILDBUDDY_CREDENTIAL. Targets will be built and tested remotely."
-    sudo mkdir -p $BAZEL_BUILDBUDDY_CREDENTIAL && sudo chmod a+rwx $BAZEL_BUILDBUDDY_CREDENTIAL
-    echo $BAZEL_BUILDBUDDY_CERT | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-cert.pem"
-    echo $BAZEL_BUILDBUDDY_KEY | base64 -d > "$BAZEL_BUILDBUDDY_CREDENTIAL/buildbuddy-key.pem"
+if [[ -n "$BAZEL_CACHE_URL" ]]; then
+    echo "Installing remote cache credential..."
+    BAZEL_CACHE_CREDENTIAL=/opt/credentials/
+    echo "A remote cache credential is found and will be saved to $BAZEL_CACHE_CREDENTIAL. Artifact and test results will be cached remotely."
+    sudo mkdir -p $BAZEL_CACHE_CREDENTIAL && sudo chmod a+rwx $BAZEL_CACHE_CREDENTIAL
+    ( echo "build --remote_cache=$BAZEL_CACHE_URL"; echo "test --remote_cache=$BAZEL_CACHE_URL"; echo "run --remote_cache=$BAZEL_CACHE_URL" ) >> "$BAZEL_CACHE_CREDENTIAL/bazel-remote-cache.rc"
     echo "The RBE credential has been installed!"
     echo "Configuring Python..."
-    # setting the exact version of Python 3 and Python 2, respectively
-    pyenv install -s 3.6.10
-    pyenv global 3.6.10 system
+    pyenv global system system
 else
     echo "No RBE credential found. Bazel will be executed locally without RBE support."
     echo "Configuring Python..."


### PR DESCRIPTION
## What is the goal of this PR?

Allow our repositories to use Bazel cache we host ourselves at https://bazel.grakn.ai

## What are the changes implemented in this PR?

Configure the Bazel cache for the build if `$BAZEL_CACHE_URL` environment variable is found