### PR TITLE
Upgrade @rules_docker to latest release

### DIFF
--- a/distribution/docker/deps.bzl
+++ b/distribution/docker/deps.bzl
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 def deps():
     http_archive(
         name = "io_bazel_rules_docker",
-        sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
-        strip_prefix = "rules_docker-0.15.0",
-        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
+        sha256 = "95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",
+        strip_prefix = "rules_docker-0.16.0",
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.16.0/rules_docker-v0.16.0.tar.gz"],
         patches = [
             "@graknlabs_dependencies//distribution/docker:bazelbuild-rules-docker-fix-tarfile-format.patch",
         ],


### PR DESCRIPTION
## What is the goal of this PR?

Upgrade rules for building Docker images to help upgrade whole build infrastructure (Bazel 4.0.0, Java 11)

## What are the changes implemented in this PR?

Bump `rules_docker` version to `0.16.0` (latest release)