### PR TITLE
Upgrade Bazel to 4.0.0

### DIFF
--- a/tool/bazelinstall/linux.sh
+++ b/tool/bazelinstall/linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-BAZEL_VERSION=3.3.1
+BAZEL_VERSION=4.0.0
 
 curl -OL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 chmod +x bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh

--- a/tool/bazelinstall/mac.sh
+++ b/tool/bazelinstall/mac.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
-BAZEL_VERSION=3.3.1
+BAZEL_VERSION=4.0.0
 
-brew install --cask homebrew/cask-versions/adoptopenjdk8
 curl -OL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 chmod +x bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh
 sudo ./bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh


### PR DESCRIPTION
## What is the goal of this PR?

Upgrade Bazel versions in `tool/bazelinstall` to latest release of Bazel.

## What are the changes implemented in this PR?

Bump the Bazel version to 4.0.0
Remove unneeded installation of Java 8 in macOS-specific script