### PR TITLE
Revert Helm repo to upstream

### DIFF
--- a/distribution/helm/deps.bzl
+++ b/distribution/helm/deps.bzl
@@ -1,9 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def deps():
-    git_repository(
+    http_archive(
         name = "com_github_masmovil_bazel_rules",
-        commit = "6dad38b14bcb3f060936a249763097304d50e144",
-        # TODO: revert to upstream once masmovil/bazel-rules#19 is merged
-        remote = "https://github.com/graknlabs/masmovil-bazel-rules.git",
+        urls = ["https://github.com/masmovil/bazel-rules/archive/9c9303cbdf451c42513377f13ed3aa7fb63ca80f.tar.gz"],
+        strip_prefix = "bazel-rules-9c9303cbdf451c42513377f13ed3aa7fb63ca80f",
+        sha256 = "32f49873cadc625774858091c872c2500a6d80e365fca2e37a5ee573c7df9801",
     )


### PR DESCRIPTION
## What is the goal of this PR?

Use upstream repo for Helm rules

## What are the changes implemented in this PR?

As our changes are accepted into https://github.com/masmovil/bazel-rules we can now proceed with using upstream rules.